### PR TITLE
fix: isolate bm-local runs from the operator's personal Basic Memory config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ benchmarks/logs/
 benchmarks/datasets/locomo/locomo10.json
 benchmarks/datasets/locomo/locomo10.provenance.json
 .env
+benchmarks/bm-home/

--- a/src/basic_memory_benchmarks/providers/bm_local.py
+++ b/src/basic_memory_benchmarks/providers/bm_local.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
 import subprocess
 import threading
@@ -37,11 +38,13 @@ class _WarmMcpClient:
         *,
         command: str = "bm",
         args: list[str] | None = None,
+        env: dict[str, str] | None = None,
         startup_timeout_seconds: float = 30.0,
         request_timeout_seconds: float = 60.0,
     ) -> None:
         self._command = command
         self._args = args or ["mcp"]
+        self._env = env
         self._startup_timeout_seconds = startup_timeout_seconds
         self._request_timeout_seconds = request_timeout_seconds
         self._requests: Queue[_McpToolRequest | None] = Queue()
@@ -50,7 +53,7 @@ class _WarmMcpClient:
         self._thread: threading.Thread | None = None
 
     async def _serve(self) -> None:
-        params = StdioServerParameters(command=self._command, args=self._args)
+        params = StdioServerParameters(command=self._command, args=self._args, env=self._env)
         async with stdio_client(params) as (read_stream, write_stream):
             async with ClientSession(read_stream, write_stream) as session:
                 await session.initialize()
@@ -120,6 +123,20 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
         self._status_json_supported: bool | None = None
         self._mcp: _WarmMcpClient | None = None
         self._bm_command_prefix: list[str] = ["bm"]
+        self._bm_env: dict[str, str] | None = None
+
+    @staticmethod
+    def _isolated_bm_env() -> dict[str, str]:
+        # The benchmark must not depend on (or mutate) the operator's personal
+        # Basic Memory config — e.g. a cloud-mode setup would route search_notes
+        # through cloud.basicmemory.com. BASIC_MEMORY_CONFIG_DIR scopes config,
+        # database, and project registry to a benchmark-owned directory.
+        bm_home = Path("benchmarks/bm-home").resolve()
+        bm_home.mkdir(parents=True, exist_ok=True)
+        env = dict(os.environ)
+        env.pop("BASIC_MEMORY_CLOUD_MODE", None)
+        env["BASIC_MEMORY_CONFIG_DIR"] = str(bm_home)
+        return env
 
     def _project_name(self, run_config: RunConfig) -> str:
         if self._resolved_project_name is not None:
@@ -141,7 +158,7 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
         *,
         check: bool = True,
     ) -> subprocess.CompletedProcess:
-        return run_command(self._bm_command_prefix + args, check=check)
+        return run_command(self._bm_command_prefix + args, check=check, env=self._bm_env)
 
     @staticmethod
     def _extract_existing_project_name(message: str) -> str | None:
@@ -259,6 +276,7 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
 
     def ingest(self, corpus_path: Path, run_config: RunConfig) -> None:
         self._bm_command_prefix = self._resolve_bm_command_prefix(run_config)
+        self._bm_env = self._isolated_bm_env()
         self._status_json_supported = None
         project_name = self._project_name(run_config)
 
@@ -290,7 +308,7 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
 
         mcp_command = self._bm_command_prefix[0]
         mcp_args = self._bm_command_prefix[1:] + ["mcp"]
-        self._mcp = _WarmMcpClient(command=mcp_command, args=mcp_args)
+        self._mcp = _WarmMcpClient(command=mcp_command, args=mcp_args, env=self._bm_env)
         self._mcp.start()
 
     @staticmethod

--- a/src/basic_memory_benchmarks/utils.py
+++ b/src/basic_memory_benchmarks/utils.py
@@ -26,8 +26,13 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def run_command(args: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess:
-    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=check)
+def run_command(
+    args: list[str],
+    cwd: Path | None = None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=check, env=env)
 
 
 def git_sha(path: Path) -> str | None:


### PR DESCRIPTION
## Summary

The `bm-local` provider runs `basic-memory` CLI commands and the warm MCP stdio server with the operator's own Basic Memory config (`~/.config/basic-memory` or equivalent). Two failure modes observed while running fresh benchmarks on a machine with a cloud-mode setup:

1. **Cloud routing kills the provider.** With a cloud-mode config, `search_notes` resolves workspaces through `cloud.basicmemory.com`; an expired JWT turns every query into `401 Unauthorized` and `bm-local` errors out of the run.
2. **BM sync mutates the benchmark repo.** A configured project with an empty path resolves to the process cwd, so the spawned MCP server synced the benchmark repo itself and injected Basic Memory frontmatter (`title`/`type`/`permalink`) into `README.md`, `AGENTS.md`, `docs/benchmarks.md`, and dataset READMEs.

## Changes

- Build an isolated environment in `ingest()`: `BASIC_MEMORY_CONFIG_DIR=benchmarks/bm-home/` (gitignored), which scopes config, project registry, SQLite index, and fastembed cache to a benchmark-owned directory — the exact isolation hook BM provides for per-process state
- Pass that env through `run_command` (new optional `env` param) for all `bm` CLI calls
- Pass it explicitly to `StdioServerParameters` — the MCP SDK only forwards a small safelisted environment to stdio servers by default, so setting vars in the parent process is not enough

## Fairness / reproducibility impact

Strictly improves reproducibility: runs no longer depend on (or mutate) whatever Basic Memory state the operator happens to have. No change to query handling, scoring, or provider configuration. First run on a fresh `bm-home` downloads the embedding model into the isolated cache once.

## Validation

- `uv run ruff check .` and `uv run pytest tests` pass
- Full LoCoMo run (1,986 queries) on a cloud-mode machine completed with `bm-local` state `ok` (previously errored with the JWT failure), and the repo's markdown files stayed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)