### PR TITLE
feat: end-to-end QA scoring stage with pluggable LLM runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,43 @@ uv run bm-bench run retrieval \
   --queries-path benchmarks/generated/locomo/queries.json
 ```
 
-### 4) Optional judge benchmark
+### 4) End-to-end QA scoring
+
+Generates an answer per query from each provider's retrieved context, then
+grades it against the expected answer with an LLM judge. This is the stage that
+produces benchmark-comparable accuracy numbers; retrieval metrics alone measure
+only the search layer.
+
+```bash
+uv run bm-bench run qa --run-dir benchmarks/runs/<run-id> \
+  --answerer claude:claude-haiku-4-5 \
+  --judge claude:claude-sonnet-4-6
+```
+
+Runner specs select the transport:
+
+- `claude:<model>` — Claude Code CLI in print mode. Bills the operator's Claude
+  subscription plan; no API key needed. Requires `claude` on PATH.
+- `openai-compat:<model>@<base_url>` — any OpenAI-compatible endpoint (Ollama,
+  LM Studio, vLLM, OpenAI). Set `OPENAI_API_KEY` if the endpoint requires auth.
+
+The same answerer and judge are used for every provider in the run, so
+cross-provider comparisons hold the model constant. Answer and judge prompts
+are fixed in `scoring/qa.py`; the answerer is instructed to abstain ("I don't
+know") when the retrieved memories don't contain the answer, and abstention is
+graded correct only when the gold answer marks the question unanswerable
+(LoCoMo adversarial cases).
+
+### 5) Optional retrieval-context judge (legacy)
+
+Scores whether the *retrieved context* contains the expected answer, without
+answer generation:
 
 ```bash
 uv run bm-bench run judge --run-dir benchmarks/runs/<run-id>
 ```
 
-### 5) Publish run artifacts
+### 6) Publish run artifacts
 
 ```bash
 uv run bm-bench publish --run-dir benchmarks/runs/<run-id>
@@ -110,6 +140,8 @@ Per run (`benchmarks/runs/<run-id>/`):
 - `provider-status.json`
 - `per-query-retrieval.jsonl`
 - `retrieval-summary.json`
+- `per-query-qa.jsonl` (optional)
+- `qa-summary.json` (optional)
 - `per-query-judge.jsonl` (optional)
 - `judge-summary.json` (optional)
 - `summary.md`

--- a/src/basic_memory_benchmarks/cli.py
+++ b/src/basic_memory_benchmarks/cli.py
@@ -13,7 +13,7 @@ from basic_memory_benchmarks.converters.locomo_to_corpus import convert_locomo_t
 from basic_memory_benchmarks.datasets.locomo import LOCOMO_URL, fetch_locomo_dataset
 from basic_memory_benchmarks.models import DatasetProvenance, RunConfig
 from basic_memory_benchmarks.reporting.compare import compare_provider_metric, load_retrieval_summary
-from basic_memory_benchmarks.runner import run_judge, run_retrieval
+from basic_memory_benchmarks.runner import run_judge, run_qa_stage, run_retrieval
 from basic_memory_benchmarks.utils import sha256_file
 
 app = typer.Typer(help="Basic Memory benchmark suite")
@@ -108,6 +108,31 @@ def run_retrieval_command(
 
     run_dir = run_retrieval(run_config=config, dataset=provenance)
     console.print(f"Retrieval run complete: [green]{run_dir}[/green]")
+
+
+@run_app.command("qa")
+def run_qa_command(
+    run_dir: Path = typer.Option(..., "--run-dir"),
+    answerer: str = typer.Option(
+        "claude:claude-haiku-4-5",
+        "--answerer",
+        help="Runner spec: claude:<model> or openai-compat:<model>@<base_url>",
+    ),
+    judge: str = typer.Option(
+        "claude:claude-sonnet-4-6",
+        "--judge",
+        help="Runner spec: claude:<model> or openai-compat:<model>@<base_url>",
+    ),
+    max_workers: int = typer.Option(4, "--max-workers"),
+) -> None:
+    out = run_qa_stage(
+        run_dir=run_dir,
+        answerer_spec=answerer,
+        judge_spec=judge,
+        max_workers=max_workers,
+    )
+    console.print(f"QA run complete: [green]{out}[/green]")
+    console.print(f"See [cyan]{out / 'qa-summary.json'}[/cyan]")
 
 
 @run_app.command("judge")

--- a/src/basic_memory_benchmarks/llm/__init__.py
+++ b/src/basic_memory_benchmarks/llm/__init__.py
@@ -1,0 +1,19 @@
+"""LLM runner abstractions for answer generation and judging."""
+
+from basic_memory_benchmarks.llm.runners import (
+    ClaudeCLIRunner,
+    LLMResult,
+    LLMRunner,
+    LLMRunnerError,
+    OpenAICompatRunner,
+    create_runner,
+)
+
+__all__ = [
+    "ClaudeCLIRunner",
+    "LLMResult",
+    "LLMRunner",
+    "LLMRunnerError",
+    "OpenAICompatRunner",
+    "create_runner",
+]

--- a/src/basic_memory_benchmarks/llm/runners.py
+++ b/src/basic_memory_benchmarks/llm/runners.py
@@ -1,0 +1,194 @@
+"""LLM runner abstraction for answer generation and judging.
+
+Two transports are supported:
+
+- ``claude``: shells out to the Claude Code CLI in print mode (``claude -p``).
+  Calls bill against the operator's Claude subscription plan, not an API key.
+- ``openai-compat``: POSTs to any OpenAI-compatible ``/chat/completions``
+  endpoint (Ollama, LM Studio, vLLM, or the real OpenAI API).
+
+Runner specs are strings so they can flow through CLI flags and run manifests:
+
+- ``claude:claude-haiku-4-5``
+- ``openai-compat:llama3.1@http://localhost:11434/v1``
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+import httpx
+
+
+class LLMRunnerError(RuntimeError):
+    """Raised when an LLM call fails after retries."""
+
+
+@dataclass
+class LLMResult:
+    text: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    latency_ms: float
+
+
+class LLMRunner(ABC):
+    """A minimal single-prompt completion interface."""
+
+    spec: str
+
+    @abstractmethod
+    def complete(self, prompt: str) -> LLMResult:
+        """Run one prompt to completion and return the text plus usage."""
+
+    def describe(self) -> dict[str, str]:
+        return {"spec": self.spec}
+
+
+class ClaudeCLIRunner(LLMRunner):
+    """Run prompts through ``claude -p`` (plan-billed, no API key required).
+
+    Each call is a fresh CLI session, so it pays the CLI's system-prompt cache
+    overhead per call. Token counts reported here are the conversation tokens
+    only (``usage.input_tokens`` + ``output_tokens``), which is what matters
+    for cross-provider context-size comparisons.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        claude_bin: str = "claude",
+        timeout_seconds: float = 300.0,
+        max_retries: int = 2,
+    ) -> None:
+        self.model = model
+        self.spec = f"claude:{model}"
+        self._claude_bin = claude_bin
+        self._timeout_seconds = timeout_seconds
+        self._max_retries = max_retries
+
+    def complete(self, prompt: str) -> LLMResult:
+        command = [
+            self._claude_bin,
+            "-p",
+            "--model",
+            self.model,
+            "--output-format",
+            "json",
+            "--max-turns",
+            "1",
+        ]
+        last_error: Exception | None = None
+        for _ in range(self._max_retries + 1):
+            started = time.perf_counter()
+            try:
+                completed = subprocess.run(
+                    command,
+                    input=prompt,
+                    capture_output=True,
+                    text=True,
+                    timeout=self._timeout_seconds,
+                    check=False,
+                )
+                payload = json.loads(completed.stdout)
+                if completed.returncode != 0 or payload.get("is_error"):
+                    raise LLMRunnerError(
+                        f"claude -p failed (rc={completed.returncode}): "
+                        f"{payload.get('result') or completed.stderr[:500]}"
+                    )
+                usage = payload.get("usage") or {}
+                return LLMResult(
+                    text=str(payload.get("result") or "").strip(),
+                    model=self.model,
+                    input_tokens=int(usage.get("input_tokens") or 0),
+                    output_tokens=int(usage.get("output_tokens") or 0),
+                    latency_ms=(time.perf_counter() - started) * 1000.0,
+                )
+            except (subprocess.TimeoutExpired, json.JSONDecodeError, LLMRunnerError) as exc:
+                last_error = exc
+        raise LLMRunnerError(
+            f"claude -p failed after {self._max_retries + 1} attempts: {last_error}"
+        )
+
+
+class OpenAICompatRunner(LLMRunner):
+    """Run prompts against an OpenAI-compatible chat-completions endpoint."""
+
+    def __init__(
+        self,
+        model: str,
+        base_url: str,
+        *,
+        api_key: str | None = None,
+        timeout_seconds: float = 300.0,
+        max_retries: int = 2,
+    ) -> None:
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.spec = f"openai-compat:{model}@{self.base_url}"
+        self._api_key = api_key
+        self._timeout_seconds = timeout_seconds
+        self._max_retries = max_retries
+
+    def complete(self, prompt: str) -> LLMResult:
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        body = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+        }
+        last_error: Exception | None = None
+        for _ in range(self._max_retries + 1):
+            started = time.perf_counter()
+            try:
+                response = httpx.post(
+                    f"{self.base_url}/chat/completions",
+                    json=body,
+                    headers=headers,
+                    timeout=self._timeout_seconds,
+                )
+                response.raise_for_status()
+                payload = response.json()
+                usage = payload.get("usage") or {}
+                return LLMResult(
+                    text=str(payload["choices"][0]["message"]["content"] or "").strip(),
+                    model=self.model,
+                    input_tokens=int(usage.get("prompt_tokens") or 0),
+                    output_tokens=int(usage.get("completion_tokens") or 0),
+                    latency_ms=(time.perf_counter() - started) * 1000.0,
+                )
+            except (httpx.HTTPError, KeyError, IndexError, json.JSONDecodeError) as exc:
+                last_error = exc
+        raise LLMRunnerError(
+            f"openai-compat call to {self.base_url} failed after "
+            f"{self._max_retries + 1} attempts: {last_error}"
+        )
+
+
+def create_runner(spec: str, *, api_key: str | None = None) -> LLMRunner:
+    """Build a runner from a spec string.
+
+    Formats: ``claude:<model>`` or ``openai-compat:<model>@<base_url>``.
+    """
+    transport, _, remainder = spec.partition(":")
+    if transport == "claude" and remainder:
+        return ClaudeCLIRunner(model=remainder)
+    if transport == "openai-compat" and remainder:
+        model, separator, base_url = remainder.partition("@")
+        if not separator or not model or not base_url:
+            raise ValueError(
+                f"openai-compat spec must be 'openai-compat:<model>@<base_url>', got: {spec}"
+            )
+        return OpenAICompatRunner(model=model, base_url=base_url, api_key=api_key)
+    raise ValueError(
+        f"Unknown runner spec '{spec}'. Expected 'claude:<model>' or "
+        f"'openai-compat:<model>@<base_url>'."
+    )

--- a/src/basic_memory_benchmarks/models.py
+++ b/src/basic_memory_benchmarks/models.py
@@ -96,6 +96,46 @@ class JudgeSummary(BaseModel):
     skipped_reason: str | None = None
 
 
+class QACategoryMetrics(BaseModel):
+    total: int = 0
+    correct: int = 0
+    accuracy: float = 0.0
+
+
+class QACaseResult(BaseModel):
+    provider: str
+    query_id: str
+    category: str
+    question: str
+    expected_answer: str
+    generated_answer: str
+    abstained: bool
+    correct: bool
+    judge_reason: str
+    answer_model: str
+    judge_model: str
+    answer_latency_ms: float
+    answer_input_tokens: int
+    answer_output_tokens: int
+    error: str | None = None
+
+
+class QASummary(BaseModel):
+    provider: str
+    answer_model: str
+    judge_model: str
+    total_cases: int
+    correct_count: int
+    error_count: int = 0
+    abstain_count: int = 0
+    accuracy: float
+    by_category: dict[str, QACategoryMetrics] = Field(default_factory=dict)
+    mean_answer_latency_ms: float = 0.0
+    total_answer_input_tokens: int = 0
+    total_answer_output_tokens: int = 0
+    skipped_reason: str | None = None
+
+
 class ProviderStatus(BaseModel):
     provider: str
     state: PROVIDER_STATE

--- a/src/basic_memory_benchmarks/runner.py
+++ b/src/basic_memory_benchmarks/runner.py
@@ -147,6 +147,70 @@ def run_retrieval(
     return run_dir
 
 
+def _load_retrieval_rows(run_dir: Path) -> list[PerQueryRetrievalResult]:
+    retrieval_path = run_dir / "per-query-retrieval.jsonl"
+    if not retrieval_path.exists():
+        raise FileNotFoundError(f"Missing retrieval artifact: {retrieval_path}")
+    rows: list[PerQueryRetrievalResult] = []
+    with retrieval_path.open("r", encoding="utf-8") as file:
+        for line in file:
+            line = line.strip()
+            if line:
+                rows.append(PerQueryRetrievalResult.model_validate(json.loads(line)))
+    return rows
+
+
+def run_qa_stage(
+    *,
+    run_dir: Path,
+    answerer_spec: str,
+    judge_spec: str,
+    max_workers: int = 4,
+) -> Path:
+    """Generate answers from each provider's retrieved context and judge them.
+
+    Reads per-query-retrieval.jsonl, writes per-query-qa.jsonl and
+    qa-summary.json into the same run directory.
+    """
+    from basic_memory_benchmarks.llm.runners import create_runner
+    from basic_memory_benchmarks.scoring.qa import run_qa
+
+    answerer = create_runner(answerer_spec)
+    judge = create_runner(judge_spec)
+
+    grouped: dict[str, list[PerQueryRetrievalResult]] = {}
+    for row in _load_retrieval_rows(run_dir):
+        grouped.setdefault(row.provider, []).append(row)
+
+    qa_rows = []
+    qa_summaries = []
+    for provider, provider_rows in grouped.items():
+        provider_cases, provider_summary = run_qa(
+            provider_rows,
+            provider=provider,
+            answerer=answerer,
+            judge=judge,
+            max_workers=max_workers,
+        )
+        qa_rows.extend(provider_cases)
+        qa_summaries.append(provider_summary)
+
+    qa_jsonl = run_dir / "per-query-qa.jsonl"
+    with qa_jsonl.open("w", encoding="utf-8") as file:
+        for row in qa_rows:
+            file.write(json.dumps(row.model_dump(mode="json"), sort_keys=True) + "\n")
+
+    qa_summary_path = run_dir / "qa-summary.json"
+    qa_summary_path.write_text(
+        json.dumps(
+            {"providers": [item.model_dump(mode="json") for item in qa_summaries]},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
 def run_judge(
     *,
     run_dir: Path,

--- a/src/basic_memory_benchmarks/scoring/qa.py
+++ b/src/basic_memory_benchmarks/scoring/qa.py
@@ -1,0 +1,211 @@
+"""End-to-end QA scoring: answer generation over retrieved context, then judging.
+
+This is the stage that produces comparable "memory benchmark accuracy" numbers.
+Retrieval metrics (recall/MRR) measure the search layer; QA accuracy measures
+whether an LLM holding only the retrieved memories can actually answer the
+question. Both prompts below are fixed and ship with the repo so any published
+number can be audited.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from concurrent.futures import ThreadPoolExecutor
+
+from basic_memory_benchmarks.llm.runners import LLMRunner, LLMRunnerError
+from basic_memory_benchmarks.models import (
+    PerQueryRetrievalResult,
+    QACaseResult,
+    QACategoryMetrics,
+    QASummary,
+)
+
+# The exact abstention sentinel the answer prompt requests. Judged correct only
+# when the gold answer itself indicates the question is unanswerable (e.g.
+# LoCoMo adversarial cases).
+ABSTAIN_SENTINEL = "I don't know"
+
+ANSWER_PROMPT_TEMPLATE = """\
+You are answering a question using only the retrieved memories below. The memories
+come from past conversations and notes; they may be incomplete.
+
+Question: {question}
+
+Retrieved memories:
+{context}
+
+Instructions:
+- Answer concisely using only facts found in the retrieved memories.
+- If the memories do not contain the information needed to answer, reply with
+  exactly: {abstain}
+- Do not use outside knowledge. Do not explain your reasoning.
+
+Answer:"""
+
+JUDGE_PROMPT_TEMPLATE = """\
+You are grading a question-answering system. Compare the candidate answer to the
+gold answer.
+
+Question: {question}
+Gold answer: {gold}
+Candidate answer: {candidate}
+
+Grading rules:
+- correct = true only if the candidate states the same core fact(s) as the gold
+  answer. Paraphrase, formatting, and extra correct detail are fine.
+- If the gold answer indicates the information is not available (e.g. "not
+  mentioned", "no information"), the candidate is correct only if it also
+  declines to answer (e.g. "{abstain}").
+- A candidate that declines to answer when the gold answer contains a real fact
+  is incorrect.
+- Partial answers missing a key fact are incorrect.
+
+Reply with only a JSON object: {{"correct": true or false, "reason": "<one sentence>"}}"""
+
+_JSON_OBJECT_PATTERN = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def build_answer_prompt(question: str, context: str) -> str:
+    return ANSWER_PROMPT_TEMPLATE.format(
+        question=question,
+        context=context if context.strip() else "(no memories were retrieved)",
+        abstain=ABSTAIN_SENTINEL,
+    )
+
+
+def build_judge_prompt(question: str, gold: str, candidate: str) -> str:
+    return JUDGE_PROMPT_TEMPLATE.format(
+        question=question,
+        gold=gold,
+        candidate=candidate,
+        abstain=ABSTAIN_SENTINEL,
+    )
+
+
+def parse_judge_verdict(raw: str) -> tuple[bool, str]:
+    """Extract a (correct, reason) verdict from judge output.
+
+    Judges occasionally wrap JSON in prose or code fences; take the first JSON
+    object found. A malformed verdict raises so the case is recorded as an
+    explicit error rather than silently scored.
+    """
+    match = _JSON_OBJECT_PATTERN.search(raw)
+    if not match:
+        raise ValueError(f"Judge returned no JSON object: {raw[:200]}")
+    payload = json.loads(match.group(0))
+    if not isinstance(payload.get("correct"), bool):
+        raise ValueError(f"Judge JSON missing boolean 'correct': {raw[:200]}")
+    return payload["correct"], str(payload.get("reason") or "")
+
+
+def _is_abstention(answer: str) -> bool:
+    normalized = answer.strip().strip(".").lower()
+    return normalized == ABSTAIN_SENTINEL.strip(".").lower()
+
+
+def _score_case(
+    row: PerQueryRetrievalResult,
+    provider: str,
+    answerer: LLMRunner,
+    judge: LLMRunner,
+) -> QACaseResult:
+    try:
+        answer_result = answerer.complete(
+            build_answer_prompt(row.query_text, row.retrieved_context)
+        )
+        judge_result = judge.complete(
+            build_judge_prompt(row.query_text, row.expected_answer or "", answer_result.text)
+        )
+        correct, reason = parse_judge_verdict(judge_result.text)
+        return QACaseResult(
+            provider=provider,
+            query_id=row.query_id,
+            category=row.category,
+            question=row.query_text,
+            expected_answer=row.expected_answer or "",
+            generated_answer=answer_result.text,
+            abstained=_is_abstention(answer_result.text),
+            correct=correct,
+            judge_reason=reason,
+            answer_model=answerer.spec,
+            judge_model=judge.spec,
+            answer_latency_ms=answer_result.latency_ms,
+            answer_input_tokens=answer_result.input_tokens,
+            answer_output_tokens=answer_result.output_tokens,
+        )
+    except (LLMRunnerError, ValueError, json.JSONDecodeError) as exc:
+        return QACaseResult(
+            provider=provider,
+            query_id=row.query_id,
+            category=row.category,
+            question=row.query_text,
+            expected_answer=row.expected_answer or "",
+            generated_answer="",
+            abstained=False,
+            correct=False,
+            judge_reason="",
+            answer_model=answerer.spec,
+            judge_model=judge.spec,
+            answer_latency_ms=0.0,
+            answer_input_tokens=0,
+            answer_output_tokens=0,
+            error=str(exc),
+        )
+
+
+def run_qa(
+    rows: list[PerQueryRetrievalResult],
+    *,
+    provider: str,
+    answerer: LLMRunner,
+    judge: LLMRunner,
+    max_workers: int = 4,
+) -> tuple[list[QACaseResult], QASummary]:
+    """Answer and judge every row that carries an expected answer."""
+    scorable = [row for row in rows if row.expected_answer]
+    if not scorable:
+        return [], QASummary(
+            provider=provider,
+            answer_model=answerer.spec,
+            judge_model=judge.spec,
+            total_cases=0,
+            correct_count=0,
+            error_count=0,
+            abstain_count=0,
+            accuracy=0.0,
+            skipped_reason="No expected answers available for QA scoring",
+        )
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        case_results = list(
+            pool.map(lambda row: _score_case(row, provider, answerer, judge), scorable)
+        )
+
+    by_category: dict[str, QACategoryMetrics] = {}
+    for case in case_results:
+        bucket = by_category.setdefault(case.category, QACategoryMetrics())
+        bucket.total += 1
+        bucket.correct += 1 if case.correct else 0
+    for bucket in by_category.values():
+        bucket.accuracy = bucket.correct / bucket.total if bucket.total else 0.0
+
+    correct_count = sum(1 for case in case_results if case.correct)
+    error_count = sum(1 for case in case_results if case.error)
+    summary = QASummary(
+        provider=provider,
+        answer_model=answerer.spec,
+        judge_model=judge.spec,
+        total_cases=len(case_results),
+        correct_count=correct_count,
+        error_count=error_count,
+        abstain_count=sum(1 for case in case_results if case.abstained),
+        accuracy=correct_count / len(case_results),
+        by_category=by_category,
+        mean_answer_latency_ms=(
+            sum(case.answer_latency_ms for case in case_results) / len(case_results)
+        ),
+        total_answer_input_tokens=sum(case.answer_input_tokens for case in case_results),
+        total_answer_output_tokens=sum(case.answer_output_tokens for case in case_results),
+    )
+    return case_results, summary

--- a/tests/llm/test_runners.py
+++ b/tests/llm/test_runners.py
@@ -1,0 +1,102 @@
+"""Tests for LLM runner spec parsing and transports."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from basic_memory_benchmarks.llm.runners import (
+    ClaudeCLIRunner,
+    LLMRunnerError,
+    OpenAICompatRunner,
+    create_runner,
+)
+
+
+class TestCreateRunner:
+    def test_claude_spec(self):
+        runner = create_runner("claude:claude-haiku-4-5")
+        assert isinstance(runner, ClaudeCLIRunner)
+        assert runner.model == "claude-haiku-4-5"
+        assert runner.spec == "claude:claude-haiku-4-5"
+
+    def test_openai_compat_spec(self):
+        runner = create_runner("openai-compat:llama3.1@http://localhost:11434/v1")
+        assert isinstance(runner, OpenAICompatRunner)
+        assert runner.model == "llama3.1"
+        assert runner.base_url == "http://localhost:11434/v1"
+
+    def test_openai_compat_spec_requires_base_url(self):
+        with pytest.raises(ValueError):
+            create_runner("openai-compat:llama3.1")
+
+    def test_unknown_transport_rejected(self):
+        with pytest.raises(ValueError):
+            create_runner("gemini:flash")
+
+    def test_empty_model_rejected(self):
+        with pytest.raises(ValueError):
+            create_runner("claude:")
+
+
+class TestClaudeCLIRunner:
+    def _completed(self, payload: dict, returncode: int = 0) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=json.dumps(payload), stderr=""
+        )
+
+    def test_parses_result_and_usage(self, monkeypatch):
+        payload = {
+            "is_error": False,
+            "result": "Paris",
+            "usage": {"input_tokens": 120, "output_tokens": 8},
+        }
+        captured: dict = {}
+
+        def fake_run(command, **kwargs):
+            captured["command"] = command
+            captured["input"] = kwargs.get("input")
+            return self._completed(payload)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        runner = ClaudeCLIRunner(model="claude-haiku-4-5")
+        result = runner.complete("What is the capital of France?")
+
+        assert result.text == "Paris"
+        assert result.input_tokens == 120
+        assert result.output_tokens == 8
+        assert captured["input"] == "What is the capital of France?"
+        assert "--max-turns" in captured["command"]
+        assert "claude-haiku-4-5" in captured["command"]
+
+    def test_error_payload_raises_after_retries(self, monkeypatch):
+        attempts = {"count": 0}
+
+        def fake_run(command, **kwargs):
+            attempts["count"] += 1
+            return self._completed({"is_error": True, "result": "overloaded"}, returncode=1)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        runner = ClaudeCLIRunner(model="claude-haiku-4-5", max_retries=1)
+        with pytest.raises(LLMRunnerError):
+            runner.complete("hello")
+        assert attempts["count"] == 2
+
+    def test_retry_then_success(self, monkeypatch):
+        attempts = {"count": 0}
+        good = {"is_error": False, "result": "ok", "usage": {}}
+
+        def fake_run(command, **kwargs):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                return subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="not json", stderr=""
+                )
+            return self._completed(good)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        runner = ClaudeCLIRunner(model="claude-haiku-4-5", max_retries=1)
+        assert runner.complete("hello").text == "ok"
+        assert attempts["count"] == 2

--- a/tests/test_qa_scoring.py
+++ b/tests/test_qa_scoring.py
@@ -1,0 +1,219 @@
+"""Tests for the end-to-end QA scoring stage."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from basic_memory_benchmarks.llm.runners import LLMResult, LLMRunner, LLMRunnerError
+from basic_memory_benchmarks.models import PerQueryRetrievalResult
+from basic_memory_benchmarks.scoring.qa import (
+    ABSTAIN_SENTINEL,
+    build_answer_prompt,
+    build_judge_prompt,
+    parse_judge_verdict,
+    run_qa,
+)
+
+
+class FakeRunner(LLMRunner):
+    """Returns canned responses keyed by substring match against the prompt."""
+
+    def __init__(self, responses: dict[str, str], default: str = ""):
+        self.spec = "fake:test"
+        self.responses = responses
+        self.default = default
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str) -> LLMResult:
+        self.prompts.append(prompt)
+        for needle, response in self.responses.items():
+            if needle in prompt:
+                return LLMResult(
+                    text=response, model="fake", input_tokens=10, output_tokens=5, latency_ms=1.0
+                )
+        if self.default:
+            return LLMResult(
+                text=self.default, model="fake", input_tokens=10, output_tokens=5, latency_ms=1.0
+            )
+        raise LLMRunnerError(f"No canned response for prompt: {prompt[:80]}")
+
+
+def _row(
+    query_id: str,
+    question: str,
+    expected: str | None,
+    context: str,
+    category: str = "single_hop",
+) -> PerQueryRetrievalResult:
+    return PerQueryRetrievalResult(
+        provider="bm-local",
+        query_id=query_id,
+        query_text=question,
+        category=category,
+        ground_truth=[],
+        expected_answer=expected,
+        recall_at_5=0.0,
+        recall_at_10=0.0,
+        precision_at_5=0.0,
+        mrr=0.0,
+        content_hit=False,
+        latency_ms=1.0,
+        retrieved_context=context,
+    )
+
+
+class TestPrompts:
+    def test_answer_prompt_includes_question_and_context(self):
+        prompt = build_answer_prompt("Where does Joanna live?", "Joanna lives in Austin.")
+        assert "Where does Joanna live?" in prompt
+        assert "Joanna lives in Austin." in prompt
+        assert ABSTAIN_SENTINEL in prompt
+
+    def test_answer_prompt_marks_empty_context(self):
+        prompt = build_answer_prompt("Where does Joanna live?", "   ")
+        assert "(no memories were retrieved)" in prompt
+
+    def test_judge_prompt_includes_all_parts(self):
+        prompt = build_judge_prompt("Q?", "gold fact", "candidate fact")
+        assert "Q?" in prompt
+        assert "gold fact" in prompt
+        assert "candidate fact" in prompt
+
+
+class TestParseJudgeVerdict:
+    def test_plain_json(self):
+        correct, reason = parse_judge_verdict('{"correct": true, "reason": "matches"}')
+        assert correct is True
+        assert reason == "matches"
+
+    def test_json_in_code_fence(self):
+        raw = 'Here is my verdict:\n```json\n{"correct": false, "reason": "missing fact"}\n```'
+        correct, reason = parse_judge_verdict(raw)
+        assert correct is False
+        assert reason == "missing fact"
+
+    def test_no_json_raises(self):
+        with pytest.raises(ValueError):
+            parse_judge_verdict("The answer is correct.")
+
+    def test_non_boolean_correct_raises(self):
+        with pytest.raises(ValueError):
+            parse_judge_verdict('{"correct": "yes"}')
+
+
+class TestRunQA:
+    def test_correct_and_incorrect_cases(self):
+        rows = [
+            _row("q1", "Where does Joanna live?", "Austin", "Joanna lives in Austin."),
+            _row("q2", "What is Anthony's job?", "Engineer", "Anthony enjoys hiking."),
+        ]
+        answerer = FakeRunner(
+            {
+                "Where does Joanna live?": "Austin",
+                "What is Anthony's job?": ABSTAIN_SENTINEL,
+            }
+        )
+        judge = FakeRunner(
+            {
+                "Candidate answer: Austin": '{"correct": true, "reason": "match"}',
+                f"Candidate answer: {ABSTAIN_SENTINEL}": '{"correct": false, "reason": "abstained on answerable"}',
+            }
+        )
+
+        cases, summary = run_qa(
+            rows, provider="bm-local", answerer=answerer, judge=judge, max_workers=1
+        )
+
+        assert summary.total_cases == 2
+        assert summary.correct_count == 1
+        assert summary.accuracy == 0.5
+        assert summary.abstain_count == 1
+        by_id = {case.query_id: case for case in cases}
+        assert by_id["q1"].correct is True
+        assert by_id["q2"].correct is False
+        assert by_id["q2"].abstained is True
+
+    def test_category_breakdown(self):
+        rows = [
+            _row("q1", "Q1?", "A1", "ctx", category="single_hop"),
+            _row("q2", "Q2?", "A2", "ctx", category="temporal"),
+        ]
+        answerer = FakeRunner({}, default="some answer")
+        judge = FakeRunner(
+            {
+                "Q1?": '{"correct": true, "reason": "ok"}',
+                "Q2?": '{"correct": false, "reason": "wrong"}',
+            }
+        )
+        _, summary = run_qa(
+            rows, provider="bm-local", answerer=answerer, judge=judge, max_workers=1
+        )
+
+        assert summary.by_category["single_hop"].accuracy == 1.0
+        assert summary.by_category["temporal"].accuracy == 0.0
+
+    def test_rows_without_expected_answer_are_skipped(self):
+        rows = [_row("q1", "Q1?", None, "ctx")]
+        answerer = FakeRunner({})
+        judge = FakeRunner({})
+        cases, summary = run_qa(rows, provider="bm-local", answerer=answerer, judge=judge)
+        assert cases == []
+        assert summary.skipped_reason is not None
+
+    def test_runner_error_recorded_not_raised(self):
+        rows = [
+            _row("q1", "Q1?", "A1", "ctx"),
+            _row("q2", "Q2?", "A2", "ctx"),
+        ]
+        answerer = FakeRunner({"Q2?": "answer two"})  # Q1 has no canned response -> error
+        judge = FakeRunner({}, default='{"correct": true, "reason": "ok"}')
+
+        cases, summary = run_qa(
+            rows, provider="bm-local", answerer=answerer, judge=judge, max_workers=1
+        )
+
+        by_id = {case.query_id: case for case in cases}
+        assert by_id["q1"].error is not None
+        assert by_id["q1"].correct is False
+        assert by_id["q2"].correct is True
+        assert summary.error_count == 1
+        assert summary.total_cases == 2
+
+    def test_token_and_latency_accounting(self):
+        rows = [_row("q1", "Q1?", "A1", "ctx")]
+        answerer = FakeRunner({}, default="answer")
+        judge = FakeRunner({}, default='{"correct": true, "reason": "ok"}')
+        _, summary = run_qa(rows, provider="bm-local", answerer=answerer, judge=judge)
+        assert summary.total_answer_input_tokens == 10
+        assert summary.total_answer_output_tokens == 5
+        assert summary.mean_answer_latency_ms == pytest.approx(1.0)
+
+
+class TestQAStageArtifacts:
+    def test_run_qa_stage_writes_artifacts(self, tmp_path, monkeypatch):
+        from basic_memory_benchmarks import runner as runner_module
+
+        rows = [
+            _row("q1", "Where does Joanna live?", "Austin", "Joanna lives in Austin."),
+        ]
+        retrieval_path = tmp_path / "per-query-retrieval.jsonl"
+        with retrieval_path.open("w", encoding="utf-8") as file:
+            for row in rows:
+                file.write(json.dumps(row.model_dump(mode="json")) + "\n")
+
+        fake = FakeRunner({}, default='{"correct": true, "reason": "ok"}')
+        monkeypatch.setattr("basic_memory_benchmarks.llm.runners.create_runner", lambda spec: fake)
+
+        runner_module.run_qa_stage(
+            run_dir=tmp_path,
+            answerer_spec="fake:test",
+            judge_spec="fake:test",
+            max_workers=1,
+        )
+
+        assert (tmp_path / "per-query-qa.jsonl").exists()
+        summary = json.loads((tmp_path / "qa-summary.json").read_text())
+        assert summary["providers"][0]["provider"] == "bm-local"
+        assert summary["providers"][0]["total_cases"] == 1


### PR DESCRIPTION
## Summary

Adds the missing stage between retrieval metrics and publishable benchmark numbers: per-query **answer generation over retrieved context**, followed by **LLM-judged grading** against the expected answer. Retrieval metrics (recall/MRR/content-hit) measure the search layer; QA accuracy is what memory-system comparisons are actually made on.

## What's new

**`llm/runners.py`** — `LLMRunner` abstraction with two transports:
- `claude:<model>` — Claude Code CLI print mode (`claude -p --output-format json --max-turns 1`). Bills the operator's Claude subscription plan; no API key required.
- `openai-compat:<model>@<base_url>` — any OpenAI-compatible chat-completions endpoint (Ollama, LM Studio, vLLM, OpenAI).

Both retry transient failures and report token usage + latency per call.

**`scoring/qa.py`** — fixed, auditable prompts (they ship in the repo so any number can be traced to its exact rubric):
- Answer prompt: answer from retrieved memories only; abstain with exactly "I don't know" when the context lacks the answer.
- Judge prompt: strict binary verdict as JSON. Abstention is correct **only** when the gold answer marks the question unanswerable (LoCoMo adversarial); abstaining on an answerable question is incorrect.
- Malformed judge output or runner failure is recorded as an explicit per-case `error` (scored incorrect), never silently passed.

**`run qa` CLI command** — reads `per-query-retrieval.jsonl`, writes `per-query-qa.jsonl` + `qa-summary.json` with per-category accuracy, abstain/error counts, mean answer latency, and token totals. The same answerer and judge are used for every provider in a run, holding the model constant across systems.

## Fairness properties

- Identical answerer + judge models for all providers in a run.
- Prompts are fixed in source, not configurable per provider.
- Judge model recorded in every artifact row for auditability.

## Testing

- `tests/llm/test_runners.py` — spec parsing, claude transport parsing/retry/error paths (subprocess mocked).
- `tests/test_qa_scoring.py` — prompt construction, verdict parsing (incl. code-fenced JSON), correct/incorrect/abstain scoring, category breakdown, error recording, token/latency accounting, artifact writing.
- Live smoke test against the real `claude` CLI (haiku answerer, sonnet judge): answerable case answered and judged correct; adversarial case abstained and judged correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)