### PR TITLE
feat: Penfield audit corrections for the LoCoMo answer key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ benchmarks/datasets/locomo/locomo10.provenance.json
 benchmarks/bm-home/
 benchmarks/datasets/longmemeval/longmemeval_s.json
 benchmarks/datasets/longmemeval/longmemeval_s.provenance.json
+benchmarks/datasets/locomo-audit/

--- a/README.md
+++ b/README.md
@@ -98,6 +98,28 @@ uv run bm-bench run judge --run-dir benchmarks/runs/<run-id>
 uv run bm-bench publish --run-dir benchmarks/runs/<run-id>
 ```
 
+## LoCoMo corrected answer key
+
+The April 2026 Penfield Labs audit ([locomo-audit](https://github.com/dial481/locomo-audit))
+found 156 answer-key errors in LoCoMo's 1,540 usable questions — hallucinated
+facts, temporal arithmetic mistakes, attribution errors, and wrong evidence
+citations. Published LoCoMo numbers should score against the corrected key and
+say so.
+
+```bash
+uv run bm-bench datasets fetch --dataset locomo-audit   # pinned audit revision
+uv run bm-bench convert locomo \
+  --audit-corrections benchmarks/datasets/locomo-audit/corrections.json \
+  --output-dir benchmarks/generated/locomo-corrected
+```
+
+Corrected queries replace both the expected answer (for QA scoring) and the
+evidence citations (for retrieval ground truth), and carry
+`audit_corrected: true` + the audit's error type in metadata. Every correction
+is cross-checked against the dataset's question text at conversion time, so
+audit/dataset drift fails loudly. The adversarial category remains excluded
+from headline metrics per the LoCoMo protocol.
+
 ## LongMemEval-S
 
 LongMemEval (Wu et al., ICLR 2025) gives each of its 500 questions an

--- a/justfile
+++ b/justfile
@@ -65,6 +65,12 @@ bench-convert-longmemeval-dev:
 
 bench-prepare-longmemeval: bench-fetch-longmemeval bench-convert-longmemeval
 
+bench-fetch-locomo-audit:
+    uv run bm-bench datasets fetch --dataset locomo-audit
+
+bench-convert-locomo-corrected: bench-fetch-locomo bench-fetch-locomo-audit
+    uv run bm-bench convert locomo --dataset-path {{locomo_dataset_path}} --output-dir benchmarks/generated/locomo-corrected --audit-corrections benchmarks/datasets/locomo-audit/corrections.json
+
 # Grouped retrieval over the LongMemEval-S dev slice (bm-local only)
 bench-run-longmemeval-dev:
     uv run bm-bench run retrieval \

--- a/src/basic_memory_benchmarks/cli.py
+++ b/src/basic_memory_benchmarks/cli.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from basic_memory_benchmarks.converters.locomo_to_corpus import convert_locomo_to_corpus
 from basic_memory_benchmarks.converters.longmemeval_to_corpus import convert_longmemeval_to_corpus
 from basic_memory_benchmarks.datasets.locomo import LOCOMO_URL, fetch_locomo_dataset
+from basic_memory_benchmarks.datasets.locomo_audit import fetch_locomo_audit_corrections
 from basic_memory_benchmarks.datasets.longmemeval import (
     LONGMEMEVAL_S_URL,
     fetch_longmemeval_dataset,
@@ -50,8 +51,11 @@ def datasets_fetch(
         provenance = fetch_longmemeval_dataset(
             output_path=resolved_output, url=url or LONGMEMEVAL_S_URL
         )
+    elif dataset == "locomo-audit":
+        resolved_output = output or Path("benchmarks/datasets/locomo-audit/corrections.json")
+        provenance = fetch_locomo_audit_corrections(output_path=resolved_output)
     else:
-        raise typer.BadParameter("Supported datasets: locomo, longmemeval-s")
+        raise typer.BadParameter("Supported datasets: locomo, longmemeval-s, locomo-audit")
 
     console.print(f"Downloaded {dataset} to [cyan]{resolved_output}[/cyan]")
     console.print(f"SHA256: [green]{provenance.checksum_sha256}[/green]")
@@ -64,11 +68,17 @@ def convert_locomo(
     ),
     output_dir: Path = typer.Option(Path("benchmarks/generated/locomo"), "--output-dir"),
     max_conversations: int | None = typer.Option(None, "--max-conversations"),
+    audit_corrections: Path | None = typer.Option(
+        None,
+        "--audit-corrections",
+        help="Penfield audit corrections.json; applies corrected answers/evidence",
+    ),
 ) -> None:
     docs_dir, queries_path, doc_count, query_count = convert_locomo_to_corpus(
         dataset_path=dataset_path,
         output_dir=output_dir,
         max_conversations=max_conversations,
+        audit_corrections_path=audit_corrections,
     )
     console.print(f"Docs: [cyan]{docs_dir}[/cyan] ({doc_count})")
     console.print(f"Queries: [cyan]{queries_path}[/cyan] ({query_count})")

--- a/src/basic_memory_benchmarks/converters/locomo_to_corpus.py
+++ b/src/basic_memory_benchmarks/converters/locomo_to_corpus.py
@@ -26,7 +26,11 @@ def _session_num_from_evidence(evidence_id: str) -> int | None:
 
 
 def _sorted_session_keys(conversation_blob: dict) -> list[str]:
-    keys = [k for k, v in conversation_blob.items() if re.match(r"^session_\d+$", k) and isinstance(v, list)]
+    keys = [
+        k
+        for k, v in conversation_blob.items()
+        if re.match(r"^session_\d+$", k) and isinstance(v, list)
+    ]
     return sorted(keys, key=lambda key: int(key.split("_")[1]))
 
 
@@ -34,13 +38,27 @@ def convert_locomo_to_corpus(
     dataset_path: Path,
     output_dir: Path,
     max_conversations: int | None = None,
+    audit_corrections_path: Path | None = None,
 ) -> tuple[Path, Path, int, int]:
     """Convert LoCoMo into markdown docs + query manifest.
+
+    When ``audit_corrections_path`` is given, the Penfield audit's corrected
+    answers and evidence citations replace the originals for the 156 known
+    answer-key errors. Each corrected query is cross-checked by question text
+    so audit/dataset drift fails loudly.
 
     Returns:
         docs_dir, queries_path, doc_count, query_count
     """
+    corrections: dict[str, dict] = {}
+    if audit_corrections_path is not None:
+        from basic_memory_benchmarks.datasets.locomo_audit import load_locomo_corrections
+
+        corrections = load_locomo_corrections(audit_corrections_path)
+
     conversations = load_locomo_dataset(dataset_path)
+    # Prefix slicing keeps conv_index aligned with the audit's
+    # locomo_<conv>_qa<index> ids.
     if max_conversations is not None:
         conversations = conversations[:max_conversations]
 
@@ -91,7 +109,29 @@ def convert_locomo_to_corpus(
             category_id = int(qa.get("category", 0))
             category = CATEGORY_MAP.get(category_id, f"cat_{category_id}")
 
+            answer = qa.get("answer") or qa.get("adversarial_answer")
             evidence = qa.get("evidence") or []
+            metadata: dict = {
+                "dataset_id": "locomo",
+                "conversation_id": conv_id,
+                "adversarial": category_id == 5,
+            }
+
+            correction = corrections.get(f"locomo_{conv_index}_qa{query_index}")
+            if correction is not None:
+                audit_question = str(correction.get("question", "")).strip()
+                actual_question = str(qa.get("question", "")).strip()
+                if audit_question != actual_question:
+                    raise ValueError(
+                        f"Audit correction locomo_{conv_index}_qa{query_index} does not "
+                        f"match dataset question: {audit_question!r} != {actual_question!r}"
+                    )
+                answer = correction["correct_answer"]
+                if correction.get("correct_evidence"):
+                    evidence = correction["correct_evidence"]
+                metadata["audit_corrected"] = True
+                metadata["audit_error_type"] = str(correction["error_type"])
+
             ground_truth_docs: set[str] = set()
             for evidence_id in evidence:
                 if not isinstance(evidence_id, str):
@@ -102,7 +142,6 @@ def convert_locomo_to_corpus(
                 if session_num in session_doc_id:
                     ground_truth_docs.add(session_doc_id[session_num])
 
-            answer = qa.get("answer") or qa.get("adversarial_answer")
             all_queries.append(
                 {
                     "id": f"{conv_id}-q{query_index:04d}",
@@ -111,11 +150,7 @@ def convert_locomo_to_corpus(
                     "category_id": category_id,
                     "ground_truth": sorted(ground_truth_docs),
                     "expected_answer": str(answer).strip() if answer else None,
-                    "metadata": {
-                        "dataset_id": "locomo",
-                        "conversation_id": conv_id,
-                        "adversarial": category_id == 5,
-                    },
+                    "metadata": metadata,
                 }
             )
 

--- a/src/basic_memory_benchmarks/datasets/locomo_audit.py
+++ b/src/basic_memory_benchmarks/datasets/locomo_audit.py
@@ -1,0 +1,93 @@
+"""Penfield Labs LoCoMo audit corrections.
+
+The April 2026 audit of LoCoMo (github.com/dial481/locomo-audit) found 156
+answer-key errors across the 1,540 usable questions: hallucinated facts,
+temporal arithmetic mistakes, speaker-attribution errors, and wrong evidence
+citations. Scoring against the corrected key (and citing the audit) is how a
+published LoCoMo number survives scrutiny — the original key caps a perfect
+system at roughly 93.6%.
+
+Corrections are fetched from a pinned commit so runs are reproducible, merged
+into one corrections.json keyed by the audit's question ids
+(``locomo_<conv>_qa<index>``), and applied at conversion time with a
+question-text cross-check so a dataset/audit drift fails loudly instead of
+silently mis-correcting.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+
+from basic_memory_benchmarks.models import DatasetProvenance
+from basic_memory_benchmarks.utils import sha256_file, utc_now_iso
+
+# Pinned audit revision (main as of 2026-04-02). Bump deliberately.
+LOCOMO_AUDIT_SHA = "9493fb4b4af4256ed17a18e8fd0b3cfdeec29539"
+LOCOMO_AUDIT_REPO = "dial481/locomo-audit"
+LOCOMO_AUDIT_LICENSE_NOTE = (
+    "Audit corrections by Penfield Labs (github.com/dial481/locomo-audit); "
+    "see repo LICENSE for terms."
+)
+_CONVERSATION_COUNT = 10
+
+_REQUIRED_KEYS = {"question_id", "question", "error_type", "correct_answer"}
+
+
+def _errors_url(conversation_index: int, sha: str) -> str:
+    return (
+        f"https://raw.githubusercontent.com/{LOCOMO_AUDIT_REPO}/{sha}/"
+        f"audit/errors_conv_{conversation_index}.json"
+    )
+
+
+def fetch_locomo_audit_corrections(
+    output_path: Path, sha: str = LOCOMO_AUDIT_SHA
+) -> DatasetProvenance:
+    """Download all per-conversation error files and merge them into one list."""
+    merged: list[dict] = []
+    for conversation_index in range(_CONVERSATION_COUNT):
+        response = httpx.get(_errors_url(conversation_index, sha), timeout=120)
+        response.raise_for_status()
+        records = response.json()
+        if not isinstance(records, list):
+            raise ValueError(
+                f"Audit errors file for conversation {conversation_index} is not a list"
+            )
+        merged.extend(records)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(merged, indent=2), encoding="utf-8")
+
+    provenance = DatasetProvenance(
+        dataset_id="locomo-audit",
+        source_url=f"https://github.com/{LOCOMO_AUDIT_REPO}/tree/{sha}/audit",
+        checksum_sha256=sha256_file(output_path),
+        license_note=LOCOMO_AUDIT_LICENSE_NOTE,
+        fetched_at_utc=utc_now_iso(),
+    )
+    output_path.with_suffix(".provenance.json").write_text(
+        json.dumps(provenance.model_dump(mode="json"), indent=2),
+        encoding="utf-8",
+    )
+    return provenance
+
+
+def load_locomo_corrections(path: Path) -> dict[str, dict]:
+    """Load merged corrections keyed by audit question id."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError(f"Corrections file must contain a list: {path}")
+
+    corrections: dict[str, dict] = {}
+    for record in payload:
+        if not isinstance(record, dict) or not _REQUIRED_KEYS.issubset(record):
+            missing = _REQUIRED_KEYS - set(record) if isinstance(record, dict) else _REQUIRED_KEYS
+            raise ValueError(f"Corrections record missing keys {sorted(missing)}: {path}")
+        question_id = str(record["question_id"])
+        if question_id in corrections:
+            raise ValueError(f"Duplicate correction for {question_id}: {path}")
+        corrections[question_id] = record
+    return corrections

--- a/tests/converters/test_locomo_audit_corrections.py
+++ b/tests/converters/test_locomo_audit_corrections.py
@@ -1,0 +1,129 @@
+"""Tests for applying Penfield audit corrections during LoCoMo conversion."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from basic_memory_benchmarks.converters.locomo_to_corpus import convert_locomo_to_corpus
+from basic_memory_benchmarks.datasets.locomo_audit import load_locomo_corrections
+
+
+def _locomo_blob() -> list[dict]:
+    return [
+        {
+            "conversation": {
+                "session_1": [
+                    {"speaker": "Melanie", "text": "I painted a sunrise last year."},
+                ],
+                "session_2": [
+                    {"speaker": "Caroline", "text": "I studied counseling."},
+                ],
+            },
+            "qa": [
+                {
+                    "question": "When did Melanie paint a sunrise?",
+                    "answer": "2022",
+                    "category": 2,
+                    "evidence": ["D1:12"],
+                },
+                {
+                    "question": "What did Caroline study?",
+                    "answer": "Psychology, counseling certification",
+                    "category": 1,
+                    "evidence": ["D2:3"],
+                },
+            ],
+        }
+    ]
+
+
+def _corrections() -> list[dict]:
+    return [
+        {
+            "question_id": "locomo_0_qa1",
+            "question": "What did Caroline study?",
+            "golden_answer": "Psychology, counseling certification",
+            "category": 1,
+            "error_type": "HALLUCINATION",
+            "cited_evidence": ["D2:3"],
+            "correct_evidence": ["D1:1"],
+            "correct_answer": "Counseling or mental health",
+        }
+    ]
+
+
+@pytest.fixture
+def converted(tmp_path):
+    dataset = tmp_path / "locomo10.json"
+    dataset.write_text(json.dumps(_locomo_blob()), encoding="utf-8")
+    corrections = tmp_path / "corrections.json"
+    corrections.write_text(json.dumps(_corrections()), encoding="utf-8")
+
+    _, queries_path, _, _ = convert_locomo_to_corpus(
+        dataset_path=dataset,
+        output_dir=tmp_path / "out",
+        audit_corrections_path=corrections,
+    )
+    return json.loads(queries_path.read_text())
+
+
+class TestAuditCorrections:
+    def test_corrected_answer_and_evidence_applied(self, converted):
+        corrected = converted[1]
+        assert corrected["expected_answer"] == "Counseling or mental health"
+        # Corrected evidence D1:1 maps to session 1's doc.
+        assert corrected["ground_truth"] == ["locomo-c00-s01"]
+        assert corrected["metadata"]["audit_corrected"] is True
+        assert corrected["metadata"]["audit_error_type"] == "HALLUCINATION"
+
+    def test_uncorrected_query_untouched(self, converted):
+        untouched = converted[0]
+        assert untouched["expected_answer"] == "2022"
+        assert untouched["ground_truth"] == ["locomo-c00-s01"]
+        assert "audit_corrected" not in untouched["metadata"]
+
+    def test_question_text_mismatch_raises(self, tmp_path):
+        dataset = tmp_path / "locomo10.json"
+        dataset.write_text(json.dumps(_locomo_blob()), encoding="utf-8")
+        bad = _corrections()
+        bad[0]["question"] = "A different question entirely?"
+        corrections = tmp_path / "corrections.json"
+        corrections.write_text(json.dumps(bad), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="does not match dataset question"):
+            convert_locomo_to_corpus(
+                dataset_path=dataset,
+                output_dir=tmp_path / "out",
+                audit_corrections_path=corrections,
+            )
+
+    def test_no_corrections_path_is_unchanged_behavior(self, tmp_path):
+        dataset = tmp_path / "locomo10.json"
+        dataset.write_text(json.dumps(_locomo_blob()), encoding="utf-8")
+        _, queries_path, _, _ = convert_locomo_to_corpus(
+            dataset_path=dataset, output_dir=tmp_path / "out"
+        )
+        queries = json.loads(queries_path.read_text())
+        assert queries[1]["expected_answer"] == "Psychology, counseling certification"
+
+
+class TestLoadCorrections:
+    def test_load_and_key_by_question_id(self, tmp_path):
+        path = tmp_path / "corrections.json"
+        path.write_text(json.dumps(_corrections()), encoding="utf-8")
+        loaded = load_locomo_corrections(path)
+        assert set(loaded) == {"locomo_0_qa1"}
+
+    def test_duplicate_question_id_raises(self, tmp_path):
+        path = tmp_path / "corrections.json"
+        path.write_text(json.dumps(_corrections() * 2), encoding="utf-8")
+        with pytest.raises(ValueError, match="Duplicate correction"):
+            load_locomo_corrections(path)
+
+    def test_missing_keys_raises(self, tmp_path):
+        path = tmp_path / "corrections.json"
+        path.write_text(json.dumps([{"question_id": "locomo_0_qa1"}]), encoding="utf-8")
+        with pytest.raises(ValueError, match="missing keys"):
+            load_locomo_corrections(path)


### PR DESCRIPTION
## Summary

Wires the [Penfield Labs LoCoMo audit](https://github.com/dial481/locomo-audit) (April 2026) into the harness: 156 answer-key errors across LoCoMo's 1,540 usable questions get corrected answers **and** corrected evidence citations at conversion time. This is a prerequisite for publishing LoCoMo numbers that withstand scrutiny — the original key is publicly documented as ~6.4% wrong.

## Design

- **Pinned provenance**: corrections fetched at audit commit `9493fb4b` and merged into one `corrections.json` with checksum provenance — runs are reproducible and the upstream can't drift silently.
- **Fail-loud application**: every correction is cross-checked against the dataset's question text during conversion; any mismatch raises instead of silently mis-correcting. (Verified: 0 mismatches across all 156 on the real dataset.)
- **Both scoring surfaces**: corrected answers feed QA scoring; corrected evidence citations feed retrieval ground truth (30 queries' ground-truth sets change).
- **Auditability**: corrected queries carry `audit_corrected: true` and the audit's `error_type` in metadata, so per-correction impact can be analyzed in any run's artifacts.
- Opt-in via `convert locomo --audit-corrections <path>`; without the flag, conversion is byte-identical to before (covered by test).

## Verification

- 8 new unit tests (application, evidence remap, question-mismatch fail-loud, loader validation, unchanged-without-flag).
- Live run against the real dataset + real audit: 156 applied, type distribution matches the audit's published counts (57 WRONG_CITATION, 33 HALLUCINATION, 26 TEMPORAL_ERROR, 24 ATTRIBUTION_ERROR, 13 AMBIGUOUS, 3 INCOMPLETE), 120 answers changed, all 1,830 untouched queries byte-identical.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)