### PR TITLE
feat: local OpenAI-compatible backend for mem0-local (zero API spend)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ benchmarks/bm-home/
 benchmarks/datasets/longmemeval/longmemeval_s.json
 benchmarks/datasets/longmemeval/longmemeval_s.provenance.json
 benchmarks/datasets/locomo-audit/
+benchmarks/.mem0-qdrant/

--- a/README.md
+++ b/README.md
@@ -161,15 +161,28 @@ uv run bm-bench run retrieval \
 
 ## Mem0 local requirements
 
-`mem0-local` requires model credentials available in environment.
+`mem0-local` needs a model backend, picked in priority order:
 
-At minimum, set:
+**1. Local OpenAI-compatible endpoint (zero API spend, e.g. Ollama):**
 
 ```bash
-export OPENAI_API_KEY=...
+export MEM0_OPENAI_COMPAT_BASE_URL=http://localhost:11434/v1
+# optional overrides (defaults shown):
+# MEM0_LLM_MODEL=qwen2.5:3b  MEM0_EMBED_MODEL=nomic-embed-text  MEM0_EMBED_DIMS=768
+# MEM0_OPENAI_COMPAT_API_KEY=local  MEM0_QDRANT_PATH=benchmarks/.mem0-qdrant
 ```
 
-If unavailable, provider status will be recorded as `SKIPPED(reason)`.
+LLM and embeddings both route to the endpoint; the qdrant store is created
+per-run with matching dimensions under `MEM0_QDRANT_PATH`.
+
+**2. OpenAI (mem0's defaults):** `export OPENAI_API_KEY=...`
+
+With neither set, provider status is recorded as `SKIPPED(reason)`.
+
+`MEM0_INFER=true` enables mem0's LLM fact-extraction at ingest (its
+recommended/headline mode); default is `false` (raw add), which matches the
+existing baselines. The active backend, models, and infer mode are recorded in
+the run manifest's provider metadata.
 
 ## BM indexing readiness
 

--- a/src/basic_memory_benchmarks/providers/mem0_local.py
+++ b/src/basic_memory_benchmarks/providers/mem0_local.py
@@ -1,4 +1,16 @@
-"""Mem0 local provider using the mem0ai package."""
+"""Mem0 local provider using the mem0ai package.
+
+Model backends, in priority order:
+
+1. **Local OpenAI-compatible endpoint** (zero API spend): set
+   ``MEM0_OPENAI_COMPAT_BASE_URL`` (e.g. ``http://localhost:11434/v1`` for
+   Ollama). LLM and embeddings both route there via mem0's ``openai``
+   provider, and the qdrant store is configured to the local embedder's
+   dimensions under a benchmark-scoped on-disk path.
+2. **OpenAI** (mem0's defaults): ``OPENAI_API_KEY`` set, no base-url override.
+
+With neither configured the provider is skipped.
+"""
 
 from __future__ import annotations
 
@@ -13,25 +25,76 @@ from basic_memory_benchmarks.exceptions import ProviderSkippedError
 from basic_memory_benchmarks.models import RunConfig, SearchHit
 from basic_memory_benchmarks.providers.base import BenchmarkProvider
 
+# Defaults for the local backend; override via env.
+_DEFAULT_LOCAL_LLM_MODEL = "qwen2.5:3b"
+_DEFAULT_LOCAL_EMBED_MODEL = "nomic-embed-text"
+_DEFAULT_LOCAL_EMBED_DIMS = 768
+
 
 class Mem0LocalProvider(BenchmarkProvider):
     name = "mem0-local"
 
     def __init__(self) -> None:
         self._memory = None
+        self._backend: str | None = None
+        self._infer: bool = os.getenv("MEM0_INFER", "false").strip().lower() == "true"
 
     def _user_id(self, run_config: RunConfig) -> str:
         return f"bm-bench-{run_config.run_id}-mem0"
 
-    def _ensure_memory(self):
+    def _local_config(self, base_url: str, run_config: RunConfig) -> dict:
+        api_key = os.getenv("MEM0_OPENAI_COMPAT_API_KEY", "local")
+        embed_dims = int(os.getenv("MEM0_EMBED_DIMS", str(_DEFAULT_LOCAL_EMBED_DIMS)))
+        qdrant_root = os.getenv("MEM0_QDRANT_PATH", "benchmarks/.mem0-qdrant")
+        # Collection + path are run-scoped: local embedding dims differ from
+        # OpenAI's, and qdrant rejects dim changes within a collection.
+        collection = f"bm_bench_{run_config.run_id}".replace("-", "_")
+        return {
+            "llm": {
+                "provider": "openai",
+                "config": {
+                    "model": os.getenv("MEM0_LLM_MODEL", _DEFAULT_LOCAL_LLM_MODEL),
+                    "openai_base_url": base_url,
+                    "api_key": api_key,
+                    "temperature": 0,
+                },
+            },
+            "embedder": {
+                "provider": "openai",
+                "config": {
+                    "model": os.getenv("MEM0_EMBED_MODEL", _DEFAULT_LOCAL_EMBED_MODEL),
+                    "openai_base_url": base_url,
+                    "api_key": api_key,
+                    "embedding_dims": embed_dims,
+                },
+            },
+            "vector_store": {
+                "provider": "qdrant",
+                "config": {
+                    "collection_name": collection,
+                    "embedding_model_dims": embed_dims,
+                    "path": str(Path(qdrant_root) / collection),
+                },
+            },
+        }
+
+    def _ensure_memory(self, run_config: RunConfig):
         if self._memory is not None:
             return self._memory
-        if not os.getenv("OPENAI_API_KEY"):
-            raise ProviderSkippedError("OPENAI_API_KEY missing for mem0-local provider")
 
         from mem0 import Memory  # Deferred import to keep startup lightweight
 
-        self._memory = Memory()
+        base_url = os.getenv("MEM0_OPENAI_COMPAT_BASE_URL")
+        if base_url:
+            self._backend = f"openai-compat:{base_url}"
+            self._memory = Memory.from_config(self._local_config(base_url, run_config))
+        elif os.getenv("OPENAI_API_KEY"):
+            self._backend = "openai-default"
+            self._memory = Memory()
+        else:
+            raise ProviderSkippedError(
+                "mem0-local needs MEM0_OPENAI_COMPAT_BASE_URL (local endpoint) or OPENAI_API_KEY"
+            )
         return self._memory
 
     @staticmethod
@@ -49,7 +112,7 @@ class Mem0LocalProvider(BenchmarkProvider):
         return "unknown"
 
     def ingest(self, corpus_path: Path, run_config: RunConfig) -> None:
-        memory = self._ensure_memory()
+        memory = self._ensure_memory(run_config)
         user_id = self._user_id(run_config)
 
         for note_path in sorted(corpus_path.rglob("*.md")):
@@ -64,7 +127,7 @@ class Mem0LocalProvider(BenchmarkProvider):
                 "conversation_id": conversation_id,
                 "dataset_id": run_config.dataset_id,
             }
-            memory.add(parsed.content, user_id=user_id, metadata=metadata, infer=False)
+            memory.add(parsed.content, user_id=user_id, metadata=metadata, infer=self._infer)
 
     @staticmethod
     def _normalize_item(item: dict) -> SearchHit:
@@ -92,7 +155,7 @@ class Mem0LocalProvider(BenchmarkProvider):
         )
 
     def search(self, query: str, limit: int, run_config: RunConfig) -> list[SearchHit]:
-        memory = self._ensure_memory()
+        memory = self._ensure_memory(run_config)
         user_id = self._user_id(run_config)
         # mem0ai 2.0: entity scoping moved from top-level user_id= to filters=,
         # and limit= became top_k=.
@@ -115,7 +178,15 @@ class Mem0LocalProvider(BenchmarkProvider):
             return
 
     def version_info(self) -> dict[str, str]:
+        metadata: dict[str, str] = {
+            "mem0_backend": self._backend or "unconfigured",
+            "mem0_infer": "true" if self._infer else "false",
+        }
+        if self._backend and self._backend.startswith("openai-compat"):
+            metadata["mem0_llm_model"] = os.getenv("MEM0_LLM_MODEL", _DEFAULT_LOCAL_LLM_MODEL)
+            metadata["mem0_embed_model"] = os.getenv("MEM0_EMBED_MODEL", _DEFAULT_LOCAL_EMBED_MODEL)
         try:
-            return {"mem0ai": version("mem0ai")}
+            metadata["mem0ai"] = version("mem0ai")
         except Exception:
-            return {}
+            pass
+        return metadata

--- a/tests/providers/test_mem0_normalization.py
+++ b/tests/providers/test_mem0_normalization.py
@@ -1,3 +1,5 @@
+import pytest
+
 from basic_memory_benchmarks.providers.mem0_local import Mem0LocalProvider
 
 
@@ -15,3 +17,52 @@ def test_mem0_normalization_prefers_nested_metadata() -> None:
     assert hit.source_doc_id == "doc-1"
     assert hit.source_path == "docs/doc-1.md"
     assert hit.score == 0.42
+
+
+class TestLocalBackendConfig:
+    def _config(self, run_id: str = "run1"):
+        from basic_memory_benchmarks.models import RunConfig
+
+        return RunConfig(
+            run_id=run_id,
+            dataset_id="t",
+            dataset_path="t",
+            corpus_dir="t",
+            queries_path="t",
+        )
+
+    def test_local_config_shape(self, monkeypatch):
+        from basic_memory_benchmarks.providers.mem0_local import Mem0LocalProvider
+
+        monkeypatch.delenv("MEM0_LLM_MODEL", raising=False)
+        monkeypatch.delenv("MEM0_EMBED_MODEL", raising=False)
+        monkeypatch.delenv("MEM0_EMBED_DIMS", raising=False)
+        provider = Mem0LocalProvider()
+        config = provider._local_config("http://localhost:11434/v1", self._config("abc-q1"))
+
+        assert config["llm"]["provider"] == "openai"
+        assert config["llm"]["config"]["openai_base_url"] == "http://localhost:11434/v1"
+        assert config["embedder"]["config"]["embedding_dims"] == 768
+        # Run-scoped, qdrant-safe collection name (no dashes).
+        assert config["vector_store"]["config"]["collection_name"] == "bm_bench_abc_q1"
+        assert config["vector_store"]["config"]["embedding_model_dims"] == 768
+
+    def test_skipped_without_any_backend(self, monkeypatch):
+        from basic_memory_benchmarks.exceptions import ProviderSkippedError
+        from basic_memory_benchmarks.providers.mem0_local import Mem0LocalProvider
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("MEM0_OPENAI_COMPAT_BASE_URL", raising=False)
+        provider = Mem0LocalProvider()
+        with pytest.raises(ProviderSkippedError, match="MEM0_OPENAI_COMPAT_BASE_URL"):
+            provider._ensure_memory(self._config())
+
+    def test_infer_env_flag(self, monkeypatch):
+        from basic_memory_benchmarks.providers.mem0_local import Mem0LocalProvider
+
+        monkeypatch.setenv("MEM0_INFER", "true")
+        assert Mem0LocalProvider()._infer is True
+        monkeypatch.setenv("MEM0_INFER", "false")
+        assert Mem0LocalProvider()._infer is False
+        monkeypatch.delenv("MEM0_INFER")
+        assert Mem0LocalProvider()._infer is False


### PR DESCRIPTION
## Summary

Removes the hard `OPENAI_API_KEY` requirement from `mem0-local`. Backend priority:

1. **`MEM0_OPENAI_COMPAT_BASE_URL`** (e.g. Ollama at `http://localhost:11434/v1`) — LLM + embeddings via mem0's `openai` provider against the local endpoint; per-run qdrant collections with matching dims (default `nomic-embed-text`/768) under `MEM0_QDRANT_PATH`.
2. **`OPENAI_API_KEY`** — mem0 stock defaults, behavior unchanged.
3. Neither — skipped, as before.

`MEM0_INFER=true` enables mem0's LLM fact-extraction at ingest (their recommended mode); default `false` preserves the June 10 baseline semantics. Backend, models, and infer mode land in `version_info` → run manifest, so every run records exactly how mem0 was configured.

## Why

Zero-API-spend benchmark runs (program decision), and fairness transparency: when we publish comparisons, reviewers can verify mem0's configuration from the manifest rather than trusting prose.

## Verification

- 3 new unit tests (config shape incl. qdrant-safe run-scoped collection naming, skip behavior, infer flag).
- Live smoke against Ollama (qwen2.5:3b + nomic-embed-text): both infer modes ingest, search ranks the correct doc first with sane scores, cleanup works, zero external API calls.
- Full suite green (74 passed), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)