### PR TITLE
feat: supermemory-local provider (self-hosted supermemory-server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,31 @@ recommended/headline mode); default is `false` (raw add), which matches the
 existing baselines. The active backend, models, and infer mode are recorded in
 the run manifest's provider metadata.
 
+## supermemory local requirements
+
+`supermemory-local` targets a running [supermemory-server](https://github.com/supermemoryai/supermemory)
+(self-hosted binary; pin v0.0.2). The provider does not manage the server —
+start it yourself and export:
+
+```bash
+export SUPERMEMORY_API_KEY=sm_...          # printed on the server's first boot
+# optional:
+# SUPERMEMORY_BASE_URL=http://localhost:6767
+# SUPERMEMORY_INGEST_TIMEOUT_S=900
+# SUPERMEMORY_SERVER_VERSION=0.0.2        # recorded in the run manifest
+```
+
+Server-side notes for fair runs: start from a **fresh** `SUPERMEMORY_DATA_DIR`
+per benchmark (upstream issue #1103: upgraded stores return empty searches),
+and configure its LLM via `OPENAI_BASE_URL`/`OPENAI_MODEL`. Ingestion is async
+(queued → ... → done|failed); the provider polls every document to a terminal
+state before searching and fails the run loudly on any failed document rather
+than silently scoring partial ingestion. Scoping is one container tag per run
+id; cleanup bulk-deletes the container.
+
+Without `SUPERMEMORY_API_KEY` or with the server unreachable, provider status
+is recorded as `SKIPPED(reason)`.
+
 ## BM indexing readiness
 
 `bm-local` verifies index readiness before querying.

--- a/src/basic_memory_benchmarks/fairness.py
+++ b/src/basic_memory_benchmarks/fairness.py
@@ -7,7 +7,9 @@ from collections.abc import Mapping, Sequence
 from basic_memory_benchmarks.models import PerQueryRetrievalResult
 
 
-def validate_fairness(results_by_provider: Mapping[str, Sequence[PerQueryRetrievalResult]]) -> list[str]:
+def validate_fairness(
+    results_by_provider: Mapping[str, Sequence[PerQueryRetrievalResult]],
+) -> list[str]:
     """Validate that all providers were scored on the same query set.
 
     Returns a list of warnings. Empty list means no mismatch detected.

--- a/src/basic_memory_benchmarks/providers/__init__.py
+++ b/src/basic_memory_benchmarks/providers/__init__.py
@@ -8,6 +8,7 @@ from basic_memory_benchmarks.providers.baseline_grep import FilesystemGrepProvid
 from basic_memory_benchmarks.providers.bm_cloud import BasicMemoryCloudProvider
 from basic_memory_benchmarks.providers.bm_local import BasicMemoryLocalProvider
 from basic_memory_benchmarks.providers.mem0_local import Mem0LocalProvider
+from basic_memory_benchmarks.providers.supermemory_local import SupermemoryLocalProvider
 from basic_memory_benchmarks.providers.zep_reference import ZepReferenceProvider
 
 
@@ -25,6 +26,8 @@ def create_provider(name: str) -> BenchmarkProvider:
         return FilesystemGrepProvider()
     if normalized == "baseline-fullcontext":
         return FullContextProvider()
+    if normalized == "supermemory-local":
+        return SupermemoryLocalProvider()
     raise ValueError(f"Unknown provider: {name}")
 
 
@@ -36,4 +39,5 @@ def provider_names() -> list[str]:
         "zep-reference",
         "baseline-grep",
         "baseline-fullcontext",
+        "supermemory-local",
     ]

--- a/src/basic_memory_benchmarks/providers/bm_local.py
+++ b/src/basic_memory_benchmarks/providers/bm_local.py
@@ -265,7 +265,9 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
                 ]
             )
             payload = json.loads(completed.stdout.strip() or "{}")
-            if isinstance(payload, dict) and self._status_json_is_ready(cast(dict[str, Any], payload)):
+            if isinstance(payload, dict) and self._status_json_is_ready(
+                cast(dict[str, Any], payload)
+            ):
                 return
 
             if time.monotonic() >= deadline:
@@ -351,7 +353,12 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
                 metadata = {}
             hits.append(
                 SearchHit(
-                    id=str(row.get("entity_id") or row.get("observation_id") or row.get("relation_id") or ""),
+                    id=str(
+                        row.get("entity_id")
+                        or row.get("observation_id")
+                        or row.get("relation_id")
+                        or ""
+                    ),
                     source_doc_id=self._doc_id_from_item(row),
                     source_path=row.get("file_path") or row.get("permalink"),
                     text=row.get("matched_chunk") or row.get("content"),
@@ -371,7 +378,9 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
     def version_info(self) -> dict[str, str]:
         metadata: dict[str, str] = {"bm_transport": "mcp-stdio"}
         if self._status_json_supported is not None:
-            metadata["bm_status_json_supported"] = "true" if self._status_json_supported else "false"
+            metadata["bm_status_json_supported"] = (
+                "true" if self._status_json_supported else "false"
+            )
         metadata["bm_command"] = " ".join(self._bm_command_prefix)
         try:
             result = self._run_bm(["--version"])

--- a/src/basic_memory_benchmarks/providers/supermemory_local.py
+++ b/src/basic_memory_benchmarks/providers/supermemory_local.py
@@ -1,0 +1,199 @@
+"""supermemory self-hosted server provider.
+
+Targets supermemory-server (github.com/supermemoryai/supermemory, local
+binary serving the Memory API on localhost:6767). The provider does not
+manage the server process — the operator starts it and supplies:
+
+- ``SUPERMEMORY_BASE_URL`` (default ``http://localhost:6767``)
+- ``SUPERMEMORY_API_KEY`` (the ``sm_...`` key printed on the server's
+  first boot; required — without it the provider is skipped)
+
+Ingestion is async on the server (queued → extracting → chunking →
+embedding → done | failed), so ingest() polls every document to a terminal
+state before returning; searching before that point silently misses
+content. Failed documents are reaped server-side after ~2 minutes, so a
+poll 404 is treated as failed.
+
+Benchmark scoping uses one container tag per run id; grouped runs get a
+fresh tag per group automatically. cleanup() bulk-deletes the container.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import frontmatter
+import httpx
+
+from basic_memory_benchmarks.exceptions import ProviderSkippedError
+from basic_memory_benchmarks.models import RunConfig, SearchHit
+from basic_memory_benchmarks.providers.base import BenchmarkProvider
+
+DEFAULT_BASE_URL = "http://localhost:6767"
+_TERMINAL_STATUSES = {"done", "failed"}
+_POLL_INTERVAL_SECONDS = 1.0
+
+
+class SupermemoryLocalProvider(BenchmarkProvider):
+    name = "supermemory-local"
+
+    def __init__(self, transport: httpx.BaseTransport | None = None) -> None:
+        self._transport = transport
+        self._client: httpx.Client | None = None
+        self._ingest_timeout_seconds = float(os.getenv("SUPERMEMORY_INGEST_TIMEOUT_S", "900"))
+        self._ingested_failures: list[str] = []
+
+    def _container_tag(self, run_config: RunConfig) -> str:
+        return f"bm-bench-{run_config.run_id}"
+
+    def _ensure_client(self) -> httpx.Client:
+        if self._client is not None:
+            return self._client
+
+        api_key = os.getenv("SUPERMEMORY_API_KEY")
+        if not api_key:
+            raise ProviderSkippedError(
+                "SUPERMEMORY_API_KEY missing for supermemory-local provider "
+                "(printed on supermemory-server first boot)"
+            )
+        base_url = os.getenv("SUPERMEMORY_BASE_URL", DEFAULT_BASE_URL)
+        self._client = httpx.Client(
+            base_url=base_url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=60.0,
+            transport=self._transport,
+        )
+
+        # Fail fast (and skip cleanly) when the server isn't up at all.
+        try:
+            self._client.post("/v3/documents/list", json={"limit": 1, "page": 1})
+        except httpx.ConnectError as exc:
+            client = self._client
+            self._client = None
+            client.close()
+            raise ProviderSkippedError(
+                f"supermemory-server unreachable at {base_url}: {exc}"
+            ) from exc
+        return self._client
+
+    def ingest(self, corpus_path: Path, run_config: RunConfig) -> None:
+        client = self._ensure_client()
+        container_tag = self._container_tag(run_config)
+        self._ingested_failures = []
+
+        pending: dict[str, str] = {}  # server doc id -> our doc id
+        for note_path in sorted(corpus_path.rglob("*.md")):
+            rel_path = note_path.relative_to(corpus_path).as_posix()
+            with note_path.open("r", encoding="utf-8") as handle:
+                parsed = frontmatter.load(handle)
+            doc_id = str(parsed.get("source_doc_id") or note_path.stem)
+            response = client.post(
+                "/v3/documents",
+                json={
+                    "content": parsed.content,
+                    "customId": doc_id,
+                    "containerTags": [container_tag],
+                    "metadata": {
+                        "source_doc_id": doc_id,
+                        "source_path": rel_path,
+                        "dataset_id": run_config.dataset_id,
+                    },
+                },
+            )
+            response.raise_for_status()
+            server_id = str(response.json().get("id") or "")
+            if not server_id:
+                raise RuntimeError(f"supermemory add returned no id for {doc_id}")
+            pending[server_id] = doc_id
+
+        # Ingestion is async server-side; wait for every document to reach a
+        # terminal state or searches will silently miss content.
+        deadline = time.monotonic() + self._ingest_timeout_seconds
+        while pending:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"supermemory ingestion timed out with {len(pending)} documents "
+                    f"still processing (timeout {self._ingest_timeout_seconds}s)"
+                )
+            for server_id, doc_id in list(pending.items()):
+                response = client.get(f"/v3/documents/{server_id}")
+                if response.status_code == 404:
+                    # Failed documents are reaped server-side after ~2 minutes.
+                    self._ingested_failures.append(doc_id)
+                    del pending[server_id]
+                    continue
+                response.raise_for_status()
+                status = str(response.json().get("status") or "")
+                if status in _TERMINAL_STATUSES:
+                    if status == "failed":
+                        self._ingested_failures.append(doc_id)
+                    del pending[server_id]
+            if pending:
+                time.sleep(_POLL_INTERVAL_SECONDS)
+
+        if self._ingested_failures:
+            # Partial ingestion silently skews retrieval metrics; fail the
+            # group/run loudly instead.
+            raise RuntimeError(
+                f"supermemory failed to ingest {len(self._ingested_failures)} documents: "
+                f"{sorted(self._ingested_failures)[:10]}"
+            )
+
+    @staticmethod
+    def _normalize_result(item: dict) -> SearchHit:
+        metadata_raw = item.get("metadata")
+        metadata: dict[str, Any] = metadata_raw if isinstance(metadata_raw, dict) else {}
+        chunks = item.get("chunks") or []
+        chunk_texts = [
+            str(chunk.get("content") or "")
+            for chunk in chunks
+            if isinstance(chunk, dict) and chunk.get("content")
+        ]
+        return SearchHit(
+            id=str(item.get("documentId") or ""),
+            source_doc_id=metadata.get("source_doc_id") or item.get("customId"),
+            source_path=metadata.get("source_path"),
+            text="\n".join(chunk_texts) if chunk_texts else item.get("title"),
+            score=float(item.get("score") or 0.0),
+            metadata=metadata,
+        )
+
+    def search(self, query: str, limit: int, run_config: RunConfig) -> list[SearchHit]:
+        client = self._ensure_client()
+        response = client.post(
+            "/v3/search",
+            json={
+                "q": query,
+                "limit": limit,
+                "containerTags": [self._container_tag(run_config)],
+            },
+        )
+        response.raise_for_status()
+        rows = response.json().get("results") or []
+        return [self._normalize_result(item) for item in rows if isinstance(item, dict)]
+
+    def cleanup(self, run_config: RunConfig) -> None:
+        if self._client is None:
+            return
+        try:
+            self._client.request(
+                "DELETE",
+                "/v3/documents/bulk",
+                json={"containerTags": [self._container_tag(run_config)]},
+            )
+        except Exception:
+            # Cleanup should never break the main benchmark flow.
+            pass
+        finally:
+            self._client.close()
+            self._client = None
+
+    def version_info(self) -> dict[str, str]:
+        return {
+            "supermemory_base_url": os.getenv("SUPERMEMORY_BASE_URL", DEFAULT_BASE_URL),
+            "supermemory_server_version": os.getenv("SUPERMEMORY_SERVER_VERSION", "unknown"),
+            "supermemory_transport": "http-v3",
+        }

--- a/src/basic_memory_benchmarks/scoring/judge.py
+++ b/src/basic_memory_benchmarks/scoring/judge.py
@@ -12,7 +12,9 @@ from typing import Any
 from basic_memory_benchmarks.models import JudgeCaseResult, JudgeSummary, PerQueryRetrievalResult
 
 
-def _deterministic_contains_eval(rows: list[PerQueryRetrievalResult], provider: str) -> tuple[list[JudgeCaseResult], JudgeSummary]:
+def _deterministic_contains_eval(
+    rows: list[PerQueryRetrievalResult], provider: str
+) -> tuple[list[JudgeCaseResult], JudgeSummary]:
     case_results: list[JudgeCaseResult] = []
     for row in rows:
         expected = (row.expected_answer or "").strip().lower()

--- a/src/basic_memory_benchmarks/scoring/retrieval.py
+++ b/src/basic_memory_benchmarks/scoring/retrieval.py
@@ -137,14 +137,18 @@ def summarize_provider(provider: str, rows: list[PerQueryRetrievalResult]) -> Re
     for row in rows:
         by_category.setdefault(row.category, []).append(row)
 
-    category_metrics = {category: _aggregate_metrics(group) for category, group in by_category.items()}
+    category_metrics = {
+        category: _aggregate_metrics(group) for category, group in by_category.items()
+    }
 
     official_rows = [
         row
         for row in rows
         if row.category in OFFICIAL_HEADLINE_CATEGORIES or row.category_id in {1, 2, 3, 4}
     ]
-    adversarial_rows = [row for row in rows if row.category == "adversarial" or row.category_id == 5]
+    adversarial_rows = [
+        row for row in rows if row.category == "adversarial" or row.category_id == 5
+    ]
 
     return RetrievalSummary(
         provider=provider,

--- a/tests/providers/test_supermemory_provider.py
+++ b/tests/providers/test_supermemory_provider.py
@@ -1,0 +1,201 @@
+"""Tests for the supermemory-local provider against a mocked v3 API."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from basic_memory_benchmarks.exceptions import ProviderSkippedError
+from basic_memory_benchmarks.models import RunConfig
+from basic_memory_benchmarks.providers.supermemory_local import SupermemoryLocalProvider
+
+
+def _config(run_id: str = "smrun") -> RunConfig:
+    return RunConfig(
+        run_id=run_id, dataset_id="t", dataset_path="t", corpus_dir="t", queries_path="t"
+    )
+
+
+def _write_doc(corpus: Path, doc_id: str, body: str) -> None:
+    corpus.mkdir(parents=True, exist_ok=True)
+    (corpus / f"{doc_id}.md").write_text(
+        f"---\ntitle: {doc_id}\nsource_doc_id: {doc_id}\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+class FakeServer:
+    """Minimal in-memory v3 API: add, status poll, search, bulk delete."""
+
+    def __init__(self, fail_doc_ids: set[str] | None = None, polls_to_done: int = 1):
+        self.docs: dict[str, dict] = {}
+        self.deleted_containers: list[list[str]] = []
+        self.fail_doc_ids = fail_doc_ids or set()
+        self.polls_to_done = polls_to_done
+        self.requests: list[tuple[str, str]] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append((request.method, request.url.path))
+        if request.headers.get("Authorization") != "Bearer sm_test":
+            return httpx.Response(401, json={"error": "unauthorized"})
+
+        if request.method == "POST" and request.url.path == "/v3/documents/list":
+            return httpx.Response(200, json={"memories": [], "pagination": {}})
+
+        if request.method == "POST" and request.url.path == "/v3/documents":
+            body = json.loads(request.content)
+            server_id = f"doc_{body['customId']}"
+            self.docs[server_id] = {"body": body, "polls": 0}
+            return httpx.Response(200, json={"id": server_id, "status": "queued"})
+
+        if request.method == "GET" and request.url.path.startswith("/v3/documents/"):
+            server_id = request.url.path.rsplit("/", 1)[-1]
+            doc = self.docs.get(server_id)
+            if doc is None:
+                return httpx.Response(404, json={"error": "not found"})
+            doc["polls"] += 1
+            custom_id = doc["body"]["customId"]
+            if doc["polls"] < self.polls_to_done:
+                return httpx.Response(200, json={"id": server_id, "status": "embedding"})
+            status = "failed" if custom_id in self.fail_doc_ids else "done"
+            return httpx.Response(200, json={"id": server_id, "status": status})
+
+        if request.method == "POST" and request.url.path == "/v3/search":
+            body = json.loads(request.content)
+            results = []
+            for server_id, doc in self.docs.items():
+                content = doc["body"]["content"]
+                if any(term.lower() in content.lower() for term in body["q"].split()):
+                    results.append(
+                        {
+                            "documentId": server_id,
+                            "title": doc["body"]["customId"],
+                            "score": 0.9,
+                            "chunks": [{"content": content, "score": 0.95, "isRelevant": True}],
+                            "metadata": doc["body"]["metadata"],
+                        }
+                    )
+            return httpx.Response(
+                200, json={"results": results[: body["limit"]], "total": len(results)}
+            )
+
+        if request.method == "DELETE" and request.url.path == "/v3/documents/bulk":
+            body = json.loads(request.content)
+            self.deleted_containers.append(body.get("containerTags") or [])
+            return httpx.Response(200, json={"deleted": len(self.docs)})
+
+        return httpx.Response(500, json={"error": f"unhandled {request.method} {request.url.path}"})
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("SUPERMEMORY_API_KEY", "sm_test")
+    monkeypatch.setenv("SUPERMEMORY_INGEST_TIMEOUT_S", "5")
+
+
+def _provider(server: FakeServer) -> SupermemoryLocalProvider:
+    return SupermemoryLocalProvider(transport=httpx.MockTransport(server.handler))
+
+
+class TestSupermemoryProvider:
+    def test_ingest_polls_to_done_then_search(self, env, tmp_path, monkeypatch):
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        server = FakeServer(polls_to_done=3)
+        corpus = tmp_path / "docs"
+        _write_doc(corpus, "doc-austin", "Joanna moved to Austin last spring.")
+        _write_doc(corpus, "doc-marathon", "Anthony runs marathons.")
+        provider = _provider(server)
+
+        provider.ingest(corpus, _config())
+        hits = provider.search("Austin", 5, _config())
+
+        assert [h.source_doc_id for h in hits] == ["doc-austin"]
+        assert hits[0].score == 0.9
+        assert "Joanna" in (hits[0].text or "")
+        # Each doc was polled to terminal state.
+        assert all(doc["polls"] >= 3 for doc in server.docs.values())
+
+    def test_container_tag_scopes_run(self, env, tmp_path):
+        server = FakeServer()
+        corpus = tmp_path / "docs"
+        _write_doc(corpus, "doc-a", "content here")
+        provider = _provider(server)
+
+        provider.ingest(corpus, _config("groupx"))
+
+        added = server.docs["doc_doc-a"]["body"]
+        assert added["containerTags"] == ["bm-bench-groupx"]
+
+    def test_failed_document_raises(self, env, tmp_path, monkeypatch):
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        server = FakeServer(fail_doc_ids={"doc-bad"})
+        corpus = tmp_path / "docs"
+        _write_doc(corpus, "doc-good", "fine content")
+        _write_doc(corpus, "doc-bad", "doomed content")
+        provider = _provider(server)
+
+        with pytest.raises(RuntimeError, match="failed to ingest 1 documents"):
+            provider.ingest(corpus, _config())
+
+    def test_poll_404_treated_as_failure(self, env, tmp_path, monkeypatch):
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        server = FakeServer()
+        corpus = tmp_path / "docs"
+        _write_doc(corpus, "doc-a", "content")
+        provider = _provider(server)
+
+        original_handler = server.handler
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET" and request.url.path.startswith("/v3/documents/"):
+                return httpx.Response(404, json={"error": "reaped"})
+            return original_handler(request)
+
+        provider = SupermemoryLocalProvider(transport=httpx.MockTransport(handler))
+        with pytest.raises(RuntimeError, match="failed to ingest"):
+            provider.ingest(corpus, _config())
+
+    def test_cleanup_bulk_deletes_container(self, env, tmp_path):
+        server = FakeServer()
+        corpus = tmp_path / "docs"
+        _write_doc(corpus, "doc-a", "content")
+        provider = _provider(server)
+
+        provider.ingest(corpus, _config("wipeme"))
+        provider.cleanup(_config("wipeme"))
+
+        assert server.deleted_containers == [["bm-bench-wipeme"]]
+
+    def test_skipped_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("SUPERMEMORY_API_KEY", raising=False)
+        provider = SupermemoryLocalProvider()
+        with pytest.raises(ProviderSkippedError, match="SUPERMEMORY_API_KEY"):
+            provider.search("anything", 5, _config())
+
+    def test_skipped_when_server_unreachable(self, env):
+        def refuse(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused", request=request)
+
+        provider = SupermemoryLocalProvider(transport=httpx.MockTransport(refuse))
+        with pytest.raises(ProviderSkippedError, match="unreachable"):
+            provider.search("anything", 5, _config())
+
+    def test_ingest_timeout_raises(self, env, tmp_path, monkeypatch):
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        # Never reaches done within the 5s budget because polls_to_done is huge.
+        server = FakeServer(polls_to_done=10_000_000)
+        monkeypatch.setenv("SUPERMEMORY_INGEST_TIMEOUT_S", "0.1")
+        corpus = tmp_path / "docs"
+        _write_doc(corpus, "doc-a", "content")
+        provider = _provider(server)
+
+        with pytest.raises(TimeoutError, match="timed out"):
+            provider.ingest(corpus, _config())
+
+    def test_factory_registration(self, env):
+        from basic_memory_benchmarks.providers import create_provider
+
+        assert isinstance(create_provider("supermemory-local"), SupermemoryLocalProvider)

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -22,16 +22,20 @@ def _row(provider: str, query_id: str) -> PerQueryRetrievalResult:
 
 
 def test_validate_fairness_ok() -> None:
-    warnings = validate_fairness({
-        "a": [_row("a", "q1")],
-        "b": [_row("b", "q1")],
-    })
+    warnings = validate_fairness(
+        {
+            "a": [_row("a", "q1")],
+            "b": [_row("b", "q1")],
+        }
+    )
     assert warnings == []
 
 
 def test_validate_fairness_mismatch() -> None:
-    warnings = validate_fairness({
-        "a": [_row("a", "q1")],
-        "b": [_row("b", "q2")],
-    })
+    warnings = validate_fairness(
+        {
+            "a": [_row("a", "q1")],
+            "b": [_row("b", "q2")],
+        }
+    )
     assert len(warnings) == 1

--- a/tests/test_manifest_schema.py
+++ b/tests/test_manifest_schema.py
@@ -22,7 +22,9 @@ def test_manifest_schema_roundtrip() -> None:
             license_note="test",
             fetched_at_utc="2026-01-01T00:00:00Z",
         ),
-        runtime=RuntimeInfo(os="test", python_version="3.12", started_at_utc="2026-01-01T00:00:00Z"),
+        runtime=RuntimeInfo(
+            os="test", python_version="3.12", started_at_utc="2026-01-01T00:00:00Z"
+        ),
         config=config,
     )
     payload = manifest.model_dump(mode="json")


### PR DESCRIPTION
## Summary

Adds `supermemory-local` as a competitor provider, targeting the self-hosted [supermemory-server](https://github.com/supermemoryai/supermemory) binary (Memory API on `localhost:6767`, pinned v0.0.2).

## Design

- **Operator-managed server**: provider connects via `SUPERMEMORY_BASE_URL` + `SUPERMEMORY_API_KEY`; skips cleanly (recorded reason) when unconfigured or unreachable.
- **Async ingestion handled correctly**: the server pipeline is `queued → extracting → chunking → embedding → done|failed`. The provider polls every document to a terminal state before returning — searching earlier silently misses content. Poll 404s = failure (server reaps failed docs after ~2 min). **Any failed document fails the run loudly** instead of silently scoring partial ingestion.
- **Run-scoped container tags** (`bm-bench-<run_id>`) — grouped (LongMemEval) runs get per-group isolation for free; cleanup bulk-deletes the container.
- **Injectable httpx transport** — tests run against a full fake v3 server (add/poll/search/bulk-delete) via `MockTransport`.
- README documents the fairness-relevant server-side setup: fresh `SUPERMEMORY_DATA_DIR` per run (upstream #1103: upgraded stores return empty searches) and LLM via `OPENAI_BASE_URL`.

## Status

API contract follows the official self-hosting docs + release assets. **Empirical validation against the real binary is pending** — installing third-party binaries needs operator authorization (install one-liner already provided in-session). Known upstream risk for our Ollama config: issue #1096 (their extraction pipeline speaks the Responses API, which Ollama rejects); if confirmed locally, the documented shim-proxy workaround is the next change.

## Verification

- 9 tests: poll-to-done, run scoping, failed-doc + 404 handling, ingest timeout, cleanup, both skip paths, factory registration.
- Full suite green (83 passed), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)