### PR TITLE
perf: warm-session reuse across groups for bm-local (3x grouped speedup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ benchmarks/datasets/longmemeval/longmemeval_s.provenance.json
 benchmarks/datasets/locomo-audit/
 benchmarks/.mem0-qdrant/
 benchmarks/datasets/convomem/
+benchmarks/.bm-homes/

--- a/src/basic_memory_benchmarks/providers/base.py
+++ b/src/basic_memory_benchmarks/providers/base.py
@@ -10,6 +10,10 @@ from basic_memory_benchmarks.models import RunConfig, SearchHit
 
 class BenchmarkProvider(ABC):
     name: str
+    # Grouped runs: when True, one provider instance serves every group
+    # (ingest called per group; cleanup called once at end of run). When
+    # False, a fresh instance is created and cleaned up per group.
+    supports_group_reuse: bool = False
 
     @abstractmethod
     def ingest(self, corpus_path: Path, run_config: RunConfig) -> None:

--- a/src/basic_memory_benchmarks/providers/bm_local.py
+++ b/src/basic_memory_benchmarks/providers/bm_local.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import subprocess
+import tempfile
 import threading
 import time
 from concurrent.futures import Future
@@ -117,30 +118,43 @@ class _WarmMcpClient:
 
 class BasicMemoryLocalProvider(BenchmarkProvider):
     name = "bm-local"
+    # One instance serves every group in a grouped run: the warm MCP session
+    # and isolated config dir are shared, projects are per-group.
+    supports_group_reuse = True
 
     def __init__(self) -> None:
-        self._resolved_project_name: str | None = None
+        # run_id -> resolved project name (grouped runs ingest many projects).
+        self._resolved_project_names: dict[str, str] = {}
         self._status_json_supported: bool | None = None
         self._mcp: _WarmMcpClient | None = None
         self._bm_command_prefix: list[str] = ["bm"]
         self._bm_env: dict[str, str] | None = None
+        self._config_dir: Path | None = None
 
-    @staticmethod
-    def _isolated_bm_env() -> dict[str, str]:
+    def _isolated_bm_env(self) -> dict[str, str]:
         # The benchmark must not depend on (or mutate) the operator's personal
         # Basic Memory config — e.g. a cloud-mode setup would route search_notes
         # through cloud.basicmemory.com. BASIC_MEMORY_CONFIG_DIR scopes config,
         # database, and project registry to a benchmark-owned directory.
-        bm_home = Path("benchmarks/bm-home").resolve()
-        bm_home.mkdir(parents=True, exist_ok=True)
+        #
+        # The directory is FRESH per provider instance: a persistent shared
+        # home rots across basic-memory versions (alembic migrations from a
+        # newer dev build brick older binaries) and leaks projects between
+        # runs. BASIC_MEMORY_HOME is dropped for the same reason.
+        if self._config_dir is None:
+            root = Path("benchmarks/.bm-homes")
+            root.mkdir(parents=True, exist_ok=True)
+            self._config_dir = Path(tempfile.mkdtemp(prefix="bm-home-", dir=root))
         env = dict(os.environ)
         env.pop("BASIC_MEMORY_CLOUD_MODE", None)
-        env["BASIC_MEMORY_CONFIG_DIR"] = str(bm_home)
+        env.pop("BASIC_MEMORY_HOME", None)
+        env["BASIC_MEMORY_CONFIG_DIR"] = str(self._config_dir)
         return env
 
     def _project_name(self, run_config: RunConfig) -> str:
-        if self._resolved_project_name is not None:
-            return self._resolved_project_name
+        resolved = self._resolved_project_names.get(run_config.run_id)
+        if resolved is not None:
+            return resolved
         return f"bm-bench-{run_config.run_id}"
 
     @staticmethod
@@ -254,6 +268,7 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
             return
 
         deadline = time.monotonic() + 120.0
+        delay = 0.25
         while True:
             completed = self._run_bm(
                 [
@@ -274,7 +289,10 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
                 raise TimeoutError(
                     f"Timed out waiting for bm status --json readiness for project '{project_name}'"
                 )
-            time.sleep(2.0)
+            # Small corpora index in well under a second; start polling fast
+            # and back off instead of paying a fixed 2s floor per group.
+            time.sleep(delay)
+            delay = min(delay * 2, 2.0)
 
     def ingest(self, corpus_path: Path, run_config: RunConfig) -> None:
         self._bm_command_prefix = self._resolve_bm_command_prefix(run_config)
@@ -299,7 +317,7 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
                     raise
                 project_name = existing
 
-        self._resolved_project_name = project_name
+        self._resolved_project_names[run_config.run_id] = project_name
 
         try:
             self._run_bm(["reindex", "--search", "--embeddings", "-p", project_name])
@@ -308,10 +326,16 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
 
         self._wait_for_index_ready(project_name)
 
-        mcp_command = self._bm_command_prefix[0]
-        mcp_args = self._bm_command_prefix[1:] + ["mcp"]
-        self._mcp = _WarmMcpClient(command=mcp_command, args=mcp_args, env=self._bm_env)
-        self._mcp.start()
+        # Trigger: first ingest of this provider instance
+        # Why: an MCP session serves projects added after it started, so one
+        # warm session covers every group in a grouped run — restarting it
+        # per group wastes seconds x hundreds of groups.
+        # Outcome: session starts once; cleanup() at end of run stops it.
+        if self._mcp is None:
+            mcp_command = self._bm_command_prefix[0]
+            mcp_args = self._bm_command_prefix[1:] + ["mcp"]
+            self._mcp = _WarmMcpClient(command=mcp_command, args=mcp_args, env=self._bm_env)
+            self._mcp.start()
 
     @staticmethod
     def _doc_id_from_item(item: dict) -> str | None:

--- a/src/basic_memory_benchmarks/runner.py
+++ b/src/basic_memory_benchmarks/runner.py
@@ -54,8 +54,13 @@ def _execute_provider_flat(
     queries: list[QueryCase],
     corpus_path: Path,
     run_config: RunConfig,
+    cleanup_after: bool = True,
 ) -> list[PerQueryRetrievalResult]:
-    """Classic single-corpus execution: one ingest, then every query."""
+    """Classic single-corpus execution: one ingest, then every query.
+
+    ``cleanup_after=False`` is the group-reuse path: the grouped executor owns
+    the provider's lifecycle and cleans up once at end of run.
+    """
     provider_rows: list[PerQueryRetrievalResult] = []
     try:
         provider.ingest(corpus_path, run_config)
@@ -72,11 +77,12 @@ def _execute_provider_flat(
                 )
             )
     finally:
-        try:
-            provider.cleanup(run_config)
-        except Exception:
-            # Cleanup errors should not mask run state.
-            pass
+        if cleanup_after:
+            try:
+                provider.cleanup(run_config)
+            except Exception:
+                # Cleanup errors should not mask run state.
+                pass
     return provider_rows
 
 
@@ -108,33 +114,51 @@ def _execute_provider_grouped(
     provider_rows: list[PerQueryRetrievalResult] = []
     failed_groups: list[str] = []
     last_provider: BenchmarkProvider | None = None
-    for group_index, (group_id, group_queries) in enumerate(sorted(groups.items())):
-        group_corpus = corpus_path / group_id / "docs"
-        if not group_corpus.exists():
-            raise FileNotFoundError(f"Missing group corpus: {group_corpus}")
-        group_config = run_config.model_copy(update={"run_id": f"{run_config.run_id}-{group_id}"})
-        provider = provider_factory(provider_name)
-        try:
-            provider_rows.extend(
-                _execute_provider_flat(
-                    provider=provider,
-                    provider_name=provider_name,
-                    queries=group_queries,
-                    corpus_path=group_corpus,
-                    run_config=group_config,
-                )
+    shared_provider = provider_factory(provider_name)
+    reuse = shared_provider.supports_group_reuse
+    try:
+        for group_index, (group_id, group_queries) in enumerate(sorted(groups.items())):
+            group_corpus = corpus_path / group_id / "docs"
+            if not group_corpus.exists():
+                raise FileNotFoundError(f"Missing group corpus: {group_corpus}")
+            group_config = run_config.model_copy(
+                update={"run_id": f"{run_config.run_id}-{group_id}"}
             )
-            last_provider = provider
-        except ProviderSkippedError:
-            # Trigger: provider signals it cannot run at all (missing creds).
-            # Why: the first group is representative; retrying hundreds of
-            # groups against an unavailable provider wastes hours.
-            # Outcome: the provider is recorded as skipped for the whole run.
-            if group_index == 0:
-                raise
-            failed_groups.append(group_id)
-        except Exception:
-            failed_groups.append(group_id)
+            # Non-reuse providers still use the shared instance for the first
+            # group so capability probing doesn't cost an extra instance.
+            if reuse or group_index == 0:
+                provider = shared_provider
+            else:
+                provider = provider_factory(provider_name)
+            try:
+                provider_rows.extend(
+                    _execute_provider_flat(
+                        provider=provider,
+                        provider_name=provider_name,
+                        queries=group_queries,
+                        corpus_path=group_corpus,
+                        run_config=group_config,
+                        cleanup_after=not reuse,
+                    )
+                )
+                last_provider = provider
+            except ProviderSkippedError:
+                # Trigger: provider signals it cannot run at all (missing creds).
+                # Why: the first group is representative; retrying hundreds of
+                # groups against an unavailable provider wastes hours.
+                # Outcome: the provider is recorded as skipped for the whole run.
+                if group_index == 0:
+                    raise
+                failed_groups.append(group_id)
+            except Exception:
+                failed_groups.append(group_id)
+    finally:
+        if reuse:
+            try:
+                shared_provider.cleanup(run_config)
+            except Exception:
+                # Cleanup errors should not mask run state.
+                pass
 
     if last_provider is None:
         raise RuntimeError(f"All {len(failed_groups)} groups failed for provider {provider_name}")

--- a/tests/test_runner_grouped.py
+++ b/tests/test_runner_grouped.py
@@ -205,3 +205,77 @@ class TestGroupedExecution:
                 dataset=_provenance(),
                 provider_factory=lambda name: RecordingProvider(),
             )
+
+
+class ReusingProvider(RecordingProvider):
+    """RecordingProvider variant that opts into group reuse."""
+
+    name = "reusing"
+    supports_group_reuse = True
+    calls: list[tuple[str, str, str]] = []
+    fail_groups: set[str] = set()
+    skip_all = False
+    instances = 0
+
+
+@pytest.fixture(autouse=True)
+def _reset_reusing_provider():
+    ReusingProvider.calls = []
+    ReusingProvider.fail_groups = set()
+    ReusingProvider.skip_all = False
+    ReusingProvider.instances = 0
+
+
+class TestGroupReuse:
+    def test_single_instance_serves_all_groups(self, tmp_path):
+        corpus_root, queries_path = _setup_grouped_corpus(tmp_path, ["qa", "qb", "qc"])
+        config = _run_config(tmp_path, corpus_root, queries_path)
+        config = config.model_copy(update={"providers": ["reusing"]})
+
+        run_dir = run_retrieval(
+            run_config=config,
+            dataset=_provenance(),
+            provider_factory=lambda name: ReusingProvider(),
+        )
+
+        assert ReusingProvider.instances == 1
+        ingests = [c for c in ReusingProvider.calls if c[0] == "ingest"]
+        assert len(ingests) == 3
+        # Per-group run ids still namespace projects within the one instance.
+        assert {run_id for _, _, run_id in ingests} == {
+            "testrun-qa",
+            "testrun-qb",
+            "testrun-qc",
+        }
+        # Cleanup exactly once, with the BASE run id, after all groups.
+        cleanups = [c for c in ReusingProvider.calls if c[0] == "cleanup"]
+        assert [run_id for _, _, run_id in cleanups] == ["testrun"]
+        assert ReusingProvider.calls[-1][0] == "cleanup"
+
+        rows = [
+            json.loads(line)
+            for line in (run_dir / "per-query-retrieval.jsonl").read_text().splitlines()
+        ]
+        assert {row["query_id"] for row in rows} == {"qa", "qb", "qc"}
+
+    def test_failed_group_does_not_stop_reuse(self, tmp_path):
+        corpus_root, queries_path = _setup_grouped_corpus(tmp_path, ["qa", "qb", "qc"])
+        ReusingProvider.fail_groups = {"qb"}
+        config = _run_config(tmp_path, corpus_root, queries_path)
+        config = config.model_copy(update={"providers": ["reusing"]})
+
+        run_dir = run_retrieval(
+            run_config=config,
+            dataset=_provenance(),
+            provider_factory=lambda name: ReusingProvider(),
+        )
+
+        assert ReusingProvider.instances == 1
+        rows = [
+            json.loads(line)
+            for line in (run_dir / "per-query-retrieval.jsonl").read_text().splitlines()
+        ]
+        assert {row["query_id"] for row in rows} == {"qa", "qc"}
+        # Cleanup still ran exactly once at the end.
+        cleanups = [c for c in ReusingProvider.calls if c[0] == "cleanup"]
+        assert len(cleanups) == 1


### PR DESCRIPTION
## Summary

Grouped runs created a fresh bm-local provider per group — new MCP session, full poll cycle — costing ~2.3 min/group (~19h extrapolated for full LongMemEval-S). This PR introduces opt-in **group reuse**: one provider instance serves every group.

## Changes

- `BenchmarkProvider.supports_group_reuse` (default `False`): grouped executor runs all groups through one instance — ingest per group, cleanup once at end with the base run config. Non-reuse providers keep exact prior semantics (covered by existing tests, unchanged).
- **bm-local opts in** — empirically verified a warm `bm mcp` session serves projects added after it started. Project-per-group namespacing unchanged; resolved names cached per run id.
- **Fresh isolated config dir per instance** (`benchmarks/.bm-homes/`, gitignored). Fixes a real bug found during this work: the persistent shared `benchmarks/bm-home` rotted across BM versions — a dev build's alembic migrations bricked the brew `bm` 0.22.0 (`Can't locate revision n7i8j9k0l1m2`). Also drops `BASIC_MEMORY_HOME` from the env.
- Status polling backs off from 0.25s instead of a fixed 2s floor.

## Measured (real BM 0.22.0, LongMemEval dev slice, 3 groups × 54 docs)

| | before | after |
|---|---|---|
| wall clock | ~7 min (~2.3 min/group) | **2:14 (~45s/group)** |
| full 500-question extrapolation | ~19 h | **~6.2 h** |
| per-query search latency | 1550 ms | **527 ms** |
| recall@5 / MRR | 1.0 / 1.0 | 1.0 / 1.0 (identical) |

Remaining per-group cost is embedding compute + reindex CLI startup — basic-memory-side, not harness overhead.

## Testing

2 new runner tests (single-instance reuse, per-group namespacing, end-of-run cleanup, failure isolation under reuse); full suite green (91), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)