### PR TITLE
fix: QA context assembly from ranked hits + LoCoMo session dates in docs

### DIFF
--- a/src/basic_memory_benchmarks/converters/locomo_to_corpus.py
+++ b/src/basic_memory_benchmarks/converters/locomo_to_corpus.py
@@ -79,18 +79,28 @@ def convert_locomo_to_corpus(
             doc_id = f"{conv_id}-s{session_num:02d}"
             session_doc_id[session_num] = doc_id
             turns = blob.get(session_key, [])
+            # The session timestamp is the anchor for every relative time
+            # expression in the dialogue ("yesterday", "last Saturday").
+            # Without it in the doc, date questions are unanswerable by any
+            # provider — LoCoMo multi_hop/temporal collapse to abstention.
+            session_date = str(blob.get(f"{session_key}_date_time", "")).strip()
+            date_suffix = f" ({session_date})" if session_date else ""
 
             lines: list[str] = [
                 "---",
-                f"title: {doc_id}",
+                f"title: {doc_id}{date_suffix}",
                 "type: note",
                 f"source_doc_id: {doc_id}",
                 "dataset_id: locomo",
                 f"conversation_id: {conv_id}",
                 f"session_number: {session_num}",
+            ]
+            if session_date:
+                lines.append(f"session_date: {session_date}")
+            lines += [
                 "---",
                 "",
-                f"# {doc_id}",
+                f"# Chat session at {session_date}" if session_date else f"# {doc_id}",
                 "",
                 "## Conversation",
             ]

--- a/src/basic_memory_benchmarks/scoring/qa.py
+++ b/src/basic_memory_benchmarks/scoring/qa.py
@@ -19,7 +19,16 @@ from basic_memory_benchmarks.models import (
     QACaseResult,
     QACategoryMetrics,
     QASummary,
+    SearchHit,
 )
+
+# Context assembly budget. Multi-fact answers (LoCoMo multi_hop, LongMemEval
+# multi-session) need material from several hits; the previous top-5
+# matched-chunk join (~1K chars) capped every provider near zero on those
+# categories despite ~0.8 retrieval recall.
+CONTEXT_MAX_HITS = 10
+CONTEXT_MAX_CHARS = 12_000
+CONTEXT_CHARS_PER_HIT = 2_500
 
 # The exact abstention sentinel the answer prompt requests. Judged correct only
 # when the gold answer itself indicates the question is unanswerable (e.g.
@@ -104,6 +113,43 @@ def _is_abstention(answer: str) -> bool:
     return normalized == ABSTAIN_SENTINEL.strip(".").lower()
 
 
+def assemble_context(hits: list[SearchHit]) -> str:
+    """Build answering context from ranked hits under a character budget.
+
+    Hits are taken in rank order; each contributes up to CONTEXT_CHARS_PER_HIT
+    characters and the total is capped at CONTEXT_MAX_CHARS. Sections are
+    numbered with their source doc so the answerer can ground multi-fact
+    answers across memories. Identical assembly for every provider.
+    """
+    sections: list[str] = []
+    used = 0
+    for rank, hit in enumerate(hits[:CONTEXT_MAX_HITS], start=1):
+        text = (hit.text or "").strip()
+        if not text:
+            continue
+        snippet = text[:CONTEXT_CHARS_PER_HIT]
+        if used + len(snippet) > CONTEXT_MAX_CHARS:
+            snippet = snippet[: CONTEXT_MAX_CHARS - used]
+            if not snippet:
+                break
+        source = hit.source_doc_id or hit.source_path or "unknown"
+        sections.append(f"[Memory {rank} | source: {source}]\n{snippet}")
+        used += len(snippet)
+        if used >= CONTEXT_MAX_CHARS:
+            break
+    return "\n\n".join(sections)
+
+
+def _row_context(row: PerQueryRetrievalResult) -> str:
+    # Prefer assembling from stored hits (richer, budget-controlled); fall
+    # back to the legacy pre-joined context for old artifacts without hits.
+    if row.hits:
+        assembled = assemble_context(row.hits)
+        if assembled:
+            return assembled
+    return row.retrieved_context
+
+
 def _question_display(row: PerQueryRetrievalResult) -> str:
     """Render the question with its ask-date when the dataset provides one.
 
@@ -125,7 +171,7 @@ def _score_case(
 ) -> QACaseResult:
     question = _question_display(row)
     try:
-        answer_result = answerer.complete(build_answer_prompt(question, row.retrieved_context))
+        answer_result = answerer.complete(build_answer_prompt(question, _row_context(row)))
         judge_result = judge.complete(
             build_judge_prompt(question, row.expected_answer or "", answer_result.text)
         )

--- a/tests/converters/test_locomo_audit_corrections.py
+++ b/tests/converters/test_locomo_audit_corrections.py
@@ -127,3 +127,29 @@ class TestLoadCorrections:
         path.write_text(json.dumps([{"question_id": "locomo_0_qa1"}]), encoding="utf-8")
         with pytest.raises(ValueError, match="missing keys"):
             load_locomo_corrections(path)
+
+
+class TestSessionDates:
+    def test_session_date_in_doc(self, tmp_path):
+        blob = _locomo_blob()
+        blob[0]["conversation"]["session_1_date_time"] = "1:56 pm on 8 May, 2023"
+        dataset = tmp_path / "locomo10.json"
+        dataset.write_text(json.dumps(blob), encoding="utf-8")
+
+        docs_dir, _, _, _ = convert_locomo_to_corpus(
+            dataset_path=dataset, output_dir=tmp_path / "out"
+        )
+        doc = (docs_dir / "locomo-c00-s01.md").read_text()
+        assert "session_date: 1:56 pm on 8 May, 2023" in doc
+        assert "# Chat session at 1:56 pm on 8 May, 2023" in doc
+        assert "title: locomo-c00-s01 (1:56 pm on 8 May, 2023)" in doc
+
+    def test_missing_date_keeps_plain_heading(self, tmp_path):
+        dataset = tmp_path / "locomo10.json"
+        dataset.write_text(json.dumps(_locomo_blob()), encoding="utf-8")
+        docs_dir, _, _, _ = convert_locomo_to_corpus(
+            dataset_path=dataset, output_dir=tmp_path / "out"
+        )
+        doc = (docs_dir / "locomo-c00-s01.md").read_text()
+        assert "session_date:" not in doc
+        assert "# locomo-c00-s01" in doc

--- a/tests/test_qa_scoring.py
+++ b/tests/test_qa_scoring.py
@@ -239,3 +239,66 @@ class TestQuestionDate:
         run_qa([row], provider="bm-local", answerer=answerer, judge=judge, max_workers=1)
 
         assert "question asked on" not in answerer.prompts[0]
+
+
+class TestAssembleContext:
+    def _hit(self, doc_id: str, text: str):
+        from basic_memory_benchmarks.models import SearchHit
+
+        return SearchHit(source_doc_id=doc_id, text=text, score=1.0)
+
+    def test_sections_numbered_with_source(self):
+        from basic_memory_benchmarks.scoring.qa import assemble_context
+
+        ctx = assemble_context(
+            [self._hit("doc-a", "alpha facts"), self._hit("doc-b", "beta facts")]
+        )
+        assert "[Memory 1 | source: doc-a]" in ctx
+        assert "alpha facts" in ctx
+        assert "[Memory 2 | source: doc-b]" in ctx
+
+    def test_budget_caps_total(self):
+        from basic_memory_benchmarks.scoring.qa import CONTEXT_MAX_CHARS, assemble_context
+
+        hits = [self._hit(f"doc-{i}", "x" * 3000) for i in range(10)]
+        ctx = assemble_context(hits)
+        # Section text alone stays within the global budget (headers excluded).
+        text_chars = sum(len(part.split("]\n", 1)[1]) for part in ctx.split("\n\n"))
+        assert text_chars <= CONTEXT_MAX_CHARS
+
+    def test_per_hit_cap(self):
+        from basic_memory_benchmarks.scoring.qa import CONTEXT_CHARS_PER_HIT, assemble_context
+
+        ctx = assemble_context([self._hit("doc-a", "z" * (CONTEXT_CHARS_PER_HIT + 500))])
+        assert ctx.count("z") == CONTEXT_CHARS_PER_HIT
+
+    def test_empty_hits_skipped(self):
+        from basic_memory_benchmarks.scoring.qa import assemble_context
+
+        ctx = assemble_context([self._hit("doc-a", ""), self._hit("doc-b", "real")])
+        assert "[Memory 2 | source: doc-b]" in ctx
+        assert "doc-a" not in ctx
+
+    def test_qa_uses_assembled_context(self):
+        from basic_memory_benchmarks.models import SearchHit
+
+        row = _row("q1", "Where does Joanna live?", "Austin", "legacy joined context")
+        row = row.model_copy(
+            update={
+                "hits": [
+                    SearchHit(source_doc_id="doc-a", text="Joanna lives in Austin.", score=1.0)
+                ]
+            }
+        )
+        answerer = FakeRunner({}, default="Austin")
+        judge = FakeRunner({}, default='{"correct": true, "reason": "ok"}')
+        run_qa([row], provider="bm-local", answerer=answerer, judge=judge, max_workers=1)
+        assert "[Memory 1 | source: doc-a]" in answerer.prompts[0]
+        assert "legacy joined context" not in answerer.prompts[0]
+
+    def test_fallback_to_legacy_context_without_hits(self):
+        row = _row("q1", "Where does Joanna live?", "Austin", "legacy joined context")
+        answerer = FakeRunner({}, default="Austin")
+        judge = FakeRunner({}, default='{"correct": true, "reason": "ok"}')
+        run_qa([row], provider="bm-local", answerer=answerer, judge=judge, max_workers=1)
+        assert "legacy joined context" in answerer.prompts[0]


### PR DESCRIPTION
## Summary

Two QA-pipeline integrity fixes from failure analysis of the first baseline matrix, where **multi_hop scored ~0 for every provider** despite ~0.8 retrieval recall.

### 1. Budget-based context assembly
The answer stage used top-5 pre-joined matched chunks (~1K chars). It now assembles from stored ranked hits under explicit budgets (10 hits / 2,500 chars each / 12,000 total) with numbered, source-attributed sections. Identical for every provider; legacy artifacts fall back.

### 2. LoCoMo session dates (the actual root cause)
The converter never wrote `session_N_date_time` into docs. Every relative time expression ('yesterday', 'last Saturday') was unanchored, making date questions — most of multi_hop, much of temporal — **unanswerable by any provider**. Models abstained honestly or hallucinated anchors (one used today's date). Session timestamps now land in frontmatter, title, and body heading, matching the LongMemEval converter.

## Evidence discipline

- Context assembly alone was re-judged on all 189 multi_hop cases: still ~0 → rejected as the root cause; kept because it's strictly better material and auditable.
- Date fix validated end-to-end on a previously-failed case: answerer derives 'two days before July 12, 2023' → July 10, judge accepts.
- **All pre-fix LoCoMo QA numbers are invalidated**; q300 will be re-run after this merges.

## Testing
8 new tests; full suite green (99), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)