### PR TITLE
fix: record answer prompt size for cross-provider context-cost reporting

### DIFF
--- a/src/basic_memory_benchmarks/models.py
+++ b/src/basic_memory_benchmarks/models.py
@@ -120,6 +120,11 @@ class QACaseResult(BaseModel):
     answer_latency_ms: float
     answer_input_tokens: int
     answer_output_tokens: int
+    # Size of the assembled prompt actually sent to the answerer. Runner
+    # token accounting is transport-dependent (the claude CLI buries the
+    # prompt in cache-creation alongside its own system overhead), so chars
+    # are the comparable cross-provider context-size measure.
+    answer_prompt_chars: int = 0
     error: str | None = None
 
 
@@ -136,6 +141,7 @@ class QASummary(BaseModel):
     mean_answer_latency_ms: float = 0.0
     total_answer_input_tokens: int = 0
     total_answer_output_tokens: int = 0
+    mean_answer_prompt_chars: float = 0.0
     skipped_reason: str | None = None
 
 

--- a/src/basic_memory_benchmarks/scoring/qa.py
+++ b/src/basic_memory_benchmarks/scoring/qa.py
@@ -170,8 +170,9 @@ def _score_case(
     judge: LLMRunner,
 ) -> QACaseResult:
     question = _question_display(row)
+    answer_prompt = build_answer_prompt(question, _row_context(row))
     try:
-        answer_result = answerer.complete(build_answer_prompt(question, _row_context(row)))
+        answer_result = answerer.complete(answer_prompt)
         judge_result = judge.complete(
             build_judge_prompt(question, row.expected_answer or "", answer_result.text)
         )
@@ -191,6 +192,7 @@ def _score_case(
             answer_latency_ms=answer_result.latency_ms,
             answer_input_tokens=answer_result.input_tokens,
             answer_output_tokens=answer_result.output_tokens,
+            answer_prompt_chars=len(answer_prompt),
         )
     except (LLMRunnerError, ValueError, json.JSONDecodeError) as exc:
         return QACaseResult(
@@ -208,6 +210,7 @@ def _score_case(
             answer_latency_ms=0.0,
             answer_input_tokens=0,
             answer_output_tokens=0,
+            answer_prompt_chars=len(answer_prompt),
             error=str(exc),
         )
 
@@ -265,5 +268,8 @@ def run_qa(
         ),
         total_answer_input_tokens=sum(case.answer_input_tokens for case in case_results),
         total_answer_output_tokens=sum(case.answer_output_tokens for case in case_results),
+        mean_answer_prompt_chars=(
+            sum(case.answer_prompt_chars for case in case_results) / len(case_results)
+        ),
     )
     return case_results, summary

--- a/tests/test_qa_scoring.py
+++ b/tests/test_qa_scoring.py
@@ -302,3 +302,13 @@ class TestAssembleContext:
         judge = FakeRunner({}, default='{"correct": true, "reason": "ok"}')
         run_qa([row], provider="bm-local", answerer=answerer, judge=judge, max_workers=1)
         assert "legacy joined context" in answerer.prompts[0]
+
+
+class TestPromptCharsAccounting:
+    def test_prompt_chars_recorded(self):
+        rows = [_row("q1", "Q1?", "A1", "some retrieved context here")]
+        answerer = FakeRunner({}, default="answer")
+        judge = FakeRunner({}, default='{"correct": true, "reason": "ok"}')
+        cases, summary = run_qa(rows, provider="bm-local", answerer=answerer, judge=judge)
+        assert cases[0].answer_prompt_chars == len(answerer.prompts[0])
+        assert summary.mean_answer_prompt_chars == cases[0].answer_prompt_chars


### PR DESCRIPTION
## Summary

The claude CLI transport buries the user prompt in `cache_creation_input_tokens` along with ~26K of its own system overhead, so `usage.input_tokens` (~10/case) wildly under-reports fed context and no clean per-prompt figure is separable.

This records `answer_prompt_chars` per QA case plus `mean_answer_prompt_chars` per provider — the comparable cross-provider context-size measure (same answerer sees them all), anchoring the accuracy-vs-context-cost axis any credible comparison needs (full-context baselines will show ~10-50x the context of retrieval systems). Runner-reported token fields stay for cost telemetry.

1 new test; suite green (100), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)