### PR TITLE
fix: record first failed-group errors in grouped provider metadata

### DIFF
--- a/src/basic_memory_benchmarks/runner.py
+++ b/src/basic_memory_benchmarks/runner.py
@@ -113,6 +113,7 @@ def _execute_provider_grouped(
 
     provider_rows: list[PerQueryRetrievalResult] = []
     failed_groups: list[str] = []
+    failed_group_errors: dict[str, str] = {}
     last_provider: BenchmarkProvider | None = None
     shared_provider = provider_factory(provider_name)
     reuse = shared_provider.supports_group_reuse
@@ -150,8 +151,12 @@ def _execute_provider_grouped(
                 if group_index == 0:
                     raise
                 failed_groups.append(group_id)
-            except Exception:
+            except Exception as exc:
                 failed_groups.append(group_id)
+                # Keep the first few error messages: a silent failed-group
+                # list is undiagnosable after a multi-hour run.
+                if len(failed_group_errors) < 3:
+                    failed_group_errors[group_id] = f"{type(exc).__name__}: {exc}"[:300]
     finally:
         if reuse:
             try:
@@ -170,6 +175,8 @@ def _execute_provider_grouped(
     if failed_groups:
         group_metadata["failed_group_count"] = str(len(failed_groups))
         group_metadata["failed_groups"] = ",".join(sorted(failed_groups)[:50])
+        for index, (group_id, message) in enumerate(sorted(failed_group_errors.items())):
+            group_metadata[f"failed_group_error_{index}"] = f"{group_id}: {message}"
     return provider_rows, last_provider, group_metadata
 
 

--- a/tests/test_runner_grouped.py
+++ b/tests/test_runner_grouped.py
@@ -279,3 +279,22 @@ class TestGroupReuse:
         # Cleanup still ran exactly once at the end.
         cleanups = [c for c in ReusingProvider.calls if c[0] == "cleanup"]
         assert len(cleanups) == 1
+
+
+class TestGroupErrorCapture:
+    def test_first_errors_recorded_in_metadata(self, tmp_path):
+        corpus_root, queries_path = _setup_grouped_corpus(tmp_path, ["qa", "qb", "qc"])
+        RecordingProvider.fail_groups = {"qb", "qc"}
+        config = _run_config(tmp_path, corpus_root, queries_path)
+
+        run_dir = run_retrieval(
+            run_config=config,
+            dataset=_provenance(),
+            provider_factory=lambda name: RecordingProvider(),
+        )
+
+        status = json.loads((run_dir / "provider-status.json").read_text())
+        meta = status[0]["metadata"]
+        assert meta["failed_group_count"] == "2"
+        assert "qb: RuntimeError: boom in qb" in meta["failed_group_error_0"]
+        assert "qc: RuntimeError: boom in qc" in meta["failed_group_error_1"]


### PR DESCRIPTION
Grouped runs record failed group ids but swallow the exceptions — mem0-local lost 24/25 LongMemEval groups and 30/30 ConvoMem groups in matrix v1 with zero diagnostic signal (and the failure doesn't reproduce in isolation). This captures the first three error messages per provider into provider-status metadata, making multi-hour runs diagnosable from their artifacts.

1 new test; suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)