### PR TITLE
feat: configurable QA context budget; single-hit providers get full budget

### DIFF
--- a/src/basic_memory_benchmarks/cli.py
+++ b/src/basic_memory_benchmarks/cli.py
@@ -204,12 +204,18 @@ def run_qa_command(
         help="Runner spec: claude:<model> or openai-compat:<model>@<base_url>",
     ),
     max_workers: int = typer.Option(4, "--max-workers"),
+    max_context_chars: int | None = typer.Option(
+        None,
+        "--max-context-chars",
+        help="Override the assembled-context budget (default 12000). Use a large value for full-context baselines.",
+    ),
 ) -> None:
     out = run_qa_stage(
         run_dir=run_dir,
         answerer_spec=answerer,
         judge_spec=judge,
         max_workers=max_workers,
+        max_context_chars=max_context_chars,
     )
     console.print(f"QA run complete: [green]{out}[/green]")
     console.print(f"See [cyan]{out / 'qa-summary.json'}[/cyan]")

--- a/src/basic_memory_benchmarks/runner.py
+++ b/src/basic_memory_benchmarks/runner.py
@@ -299,6 +299,7 @@ def run_qa_stage(
     answerer_spec: str,
     judge_spec: str,
     max_workers: int = 4,
+    max_context_chars: int | None = None,
 ) -> Path:
     """Generate answers from each provider's retrieved context and judge them.
 
@@ -306,7 +307,7 @@ def run_qa_stage(
     qa-summary.json into the same run directory.
     """
     from basic_memory_benchmarks.llm.runners import create_runner
-    from basic_memory_benchmarks.scoring.qa import run_qa
+    from basic_memory_benchmarks.scoring.qa import CONTEXT_MAX_CHARS, run_qa
 
     answerer = create_runner(answerer_spec)
     judge = create_runner(judge_spec)
@@ -324,6 +325,7 @@ def run_qa_stage(
             answerer=answerer,
             judge=judge,
             max_workers=max_workers,
+            max_context_chars=max_context_chars or CONTEXT_MAX_CHARS,
         )
         qa_rows.extend(provider_cases)
         qa_summaries.append(provider_summary)

--- a/src/basic_memory_benchmarks/scoring/qa.py
+++ b/src/basic_memory_benchmarks/scoring/qa.py
@@ -113,38 +113,45 @@ def _is_abstention(answer: str) -> bool:
     return normalized == ABSTAIN_SENTINEL.strip(".").lower()
 
 
-def assemble_context(hits: list[SearchHit]) -> str:
+def assemble_context(hits: list[SearchHit], max_chars: int = CONTEXT_MAX_CHARS) -> str:
     """Build answering context from ranked hits under a character budget.
 
-    Hits are taken in rank order; each contributes up to CONTEXT_CHARS_PER_HIT
-    characters and the total is capped at CONTEXT_MAX_CHARS. Sections are
-    numbered with their source doc so the answerer can ground multi-fact
-    answers across memories. Identical assembly for every provider.
+    Hits are taken in rank order under a total budget of ``max_chars``. The
+    per-hit cap is the larger of CONTEXT_CHARS_PER_HIT and an even split of
+    the budget across available hits, so a single-hit provider (the
+    full-context baseline) can use the whole budget rather than being
+    truncated to one hit-slice. Sections are numbered with their source doc
+    so the answerer can ground multi-fact answers across memories. Identical
+    assembly for every provider in a run.
     """
+    take = hits[:CONTEXT_MAX_HITS]
+    if not take:
+        return ""
+    per_hit_cap = max(CONTEXT_CHARS_PER_HIT, max_chars // len(take))
     sections: list[str] = []
     used = 0
-    for rank, hit in enumerate(hits[:CONTEXT_MAX_HITS], start=1):
+    for rank, hit in enumerate(take, start=1):
         text = (hit.text or "").strip()
         if not text:
             continue
-        snippet = text[:CONTEXT_CHARS_PER_HIT]
-        if used + len(snippet) > CONTEXT_MAX_CHARS:
-            snippet = snippet[: CONTEXT_MAX_CHARS - used]
+        snippet = text[:per_hit_cap]
+        if used + len(snippet) > max_chars:
+            snippet = snippet[: max_chars - used]
             if not snippet:
                 break
         source = hit.source_doc_id or hit.source_path or "unknown"
         sections.append(f"[Memory {rank} | source: {source}]\n{snippet}")
         used += len(snippet)
-        if used >= CONTEXT_MAX_CHARS:
+        if used >= max_chars:
             break
     return "\n\n".join(sections)
 
 
-def _row_context(row: PerQueryRetrievalResult) -> str:
+def _row_context(row: PerQueryRetrievalResult, max_context_chars: int) -> str:
     # Prefer assembling from stored hits (richer, budget-controlled); fall
     # back to the legacy pre-joined context for old artifacts without hits.
     if row.hits:
-        assembled = assemble_context(row.hits)
+        assembled = assemble_context(row.hits, max_chars=max_context_chars)
         if assembled:
             return assembled
     return row.retrieved_context
@@ -168,9 +175,10 @@ def _score_case(
     provider: str,
     answerer: LLMRunner,
     judge: LLMRunner,
+    max_context_chars: int = CONTEXT_MAX_CHARS,
 ) -> QACaseResult:
     question = _question_display(row)
-    answer_prompt = build_answer_prompt(question, _row_context(row))
+    answer_prompt = build_answer_prompt(question, _row_context(row, max_context_chars))
     try:
         answer_result = answerer.complete(answer_prompt)
         judge_result = judge.complete(
@@ -222,6 +230,7 @@ def run_qa(
     answerer: LLMRunner,
     judge: LLMRunner,
     max_workers: int = 4,
+    max_context_chars: int = CONTEXT_MAX_CHARS,
 ) -> tuple[list[QACaseResult], QASummary]:
     """Answer and judge every row that carries an expected answer."""
     scorable = [row for row in rows if row.expected_answer]
@@ -240,7 +249,10 @@ def run_qa(
 
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         case_results = list(
-            pool.map(lambda row: _score_case(row, provider, answerer, judge), scorable)
+            pool.map(
+                lambda row: _score_case(row, provider, answerer, judge, max_context_chars),
+                scorable,
+            )
         )
 
     by_category: dict[str, QACategoryMetrics] = {}

--- a/tests/test_qa_scoring.py
+++ b/tests/test_qa_scoring.py
@@ -266,11 +266,15 @@ class TestAssembleContext:
         text_chars = sum(len(part.split("]\n", 1)[1]) for part in ctx.split("\n\n"))
         assert text_chars <= CONTEXT_MAX_CHARS
 
-    def test_per_hit_cap(self):
+    def test_per_hit_cap_with_many_hits(self):
         from basic_memory_benchmarks.scoring.qa import CONTEXT_CHARS_PER_HIT, assemble_context
 
-        ctx = assemble_context([self._hit("doc-a", "z" * (CONTEXT_CHARS_PER_HIT + 500))])
-        assert ctx.count("z") == CONTEXT_CHARS_PER_HIT
+        # With a full hit list the per-hit cap is the slice constant; a lone
+        # hit instead gets the whole budget (see TestContextBudgetOverride).
+        hits = [self._hit(f"doc-{i}", "z" * (CONTEXT_CHARS_PER_HIT + 500)) for i in range(10)]
+        ctx = assemble_context(hits)
+        first_section = ctx.split("\n\n")[0]
+        assert first_section.count("z") == CONTEXT_CHARS_PER_HIT
 
     def test_empty_hits_skipped(self):
         from basic_memory_benchmarks.scoring.qa import assemble_context
@@ -312,3 +316,37 @@ class TestPromptCharsAccounting:
         cases, summary = run_qa(rows, provider="bm-local", answerer=answerer, judge=judge)
         assert cases[0].answer_prompt_chars == len(answerer.prompts[0])
         assert summary.mean_answer_prompt_chars == cases[0].answer_prompt_chars
+
+
+class TestContextBudgetOverride:
+    def _hit(self, doc_id: str, text: str):
+        from basic_memory_benchmarks.models import SearchHit
+
+        return SearchHit(source_doc_id=doc_id, text=text, score=1.0)
+
+    def test_single_hit_uses_full_budget(self):
+        from basic_memory_benchmarks.scoring.qa import assemble_context
+
+        # One massive hit (full-context baseline) gets the whole budget,
+        # not the per-hit slice.
+        ctx = assemble_context([self._hit("all", "z" * 50_000)], max_chars=40_000)
+        assert ctx.count("z") == 40_000
+
+    def test_budget_override_flows_through_run_qa(self):
+        from basic_memory_benchmarks.models import SearchHit
+
+        row = _row("q1", "Q?", "A", "legacy")
+        row = row.model_copy(
+            update={"hits": [SearchHit(source_doc_id="all", text="z" * 50_000, score=1.0)]}
+        )
+        answerer = FakeRunner({}, default="answer")
+        judge = FakeRunner({}, default='{"correct": true, "reason": "ok"}')
+        run_qa(
+            [row],
+            provider="p",
+            answerer=answerer,
+            judge=judge,
+            max_workers=1,
+            max_context_chars=30_000,
+        )
+        assert answerer.prompts[0].count("z") == 30_000


### PR DESCRIPTION
Matrix v1 finding: the fixed 2,500-char per-hit slice truncated the full-context baseline's single mega-hit to ~3K chars of a ~115K-token haystack → abstention on all 25 LME questions → meaningless baseline.

- `assemble_context` per-hit cap is now `max(slice, budget // hit_count)` — a lone hit can use the whole budget; full hit lists keep existing slicing.
- `run qa --max-context-chars` overrides the total budget (default 12,000) for full-context baseline passes; `mean_answer_prompt_chars` keeps the context-cost axis visible.

2 new tests + 1 updated; suite green (103), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)