### PR TITLE
fix: mem0 grouped runs lose all groups after the first (telemetry qdrant lock)

### DIFF
--- a/src/basic_memory_benchmarks/providers/mem0_local.py
+++ b/src/basic_memory_benchmarks/providers/mem0_local.py
@@ -82,6 +82,16 @@ class Mem0LocalProvider(BenchmarkProvider):
         if self._memory is not None:
             return self._memory
 
+        # Trigger: mem0 with MEM0_TELEMETRY on (its default) opens a qdrant
+        # client at a FIXED path (~/.mem0/migrations_qdrant) inside every
+        # Memory(); qdrant local mode allows one client per path per process,
+        # so the second provider instance in a grouped run dies with
+        # "Storage folder ... is already accessed" (matrix v1: 24/25 LME and
+        # 30/30 ConvoMem groups lost).
+        # Why: benchmark runs should not emit telemetry anyway.
+        # Outcome: telemetry store never created; operator can force-enable.
+        os.environ.setdefault("MEM0_TELEMETRY", "false")
+
         from mem0 import Memory  # Deferred import to keep startup lightweight
 
         base_url = os.getenv("MEM0_OPENAI_COMPAT_BASE_URL")
@@ -175,7 +185,18 @@ class Mem0LocalProvider(BenchmarkProvider):
             self._memory.delete_all(user_id=self._user_id(run_config))
         except Exception:
             # Cleanup should never break the main benchmark flow.
-            return
+            pass
+        # Release qdrant local-mode file locks even while this instance is
+        # still referenced (the grouped runner keeps the last provider for
+        # version_info), or the next instance cannot open its stores.
+        for store_attr in ("vector_store", "_telemetry_vector_store"):
+            client = getattr(getattr(self._memory, store_attr, None), "client", None)
+            if client is not None and hasattr(client, "close"):
+                try:
+                    client.close()
+                except Exception:
+                    pass
+        self._memory = None
 
     def version_info(self) -> dict[str, str]:
         metadata: dict[str, str] = {

--- a/tests/providers/test_mem0_normalization.py
+++ b/tests/providers/test_mem0_normalization.py
@@ -66,3 +66,61 @@ class TestLocalBackendConfig:
         assert Mem0LocalProvider()._infer is False
         monkeypatch.delenv("MEM0_INFER")
         assert Mem0LocalProvider()._infer is False
+
+
+class TestTelemetryLockAvoidance:
+    def test_telemetry_disabled_before_import(self, monkeypatch):
+        import os
+
+        from basic_memory_benchmarks.providers.mem0_local import Mem0LocalProvider
+
+        monkeypatch.setenv("MEM0_OPENAI_COMPAT_BASE_URL", "http://localhost:1/v1")
+        monkeypatch.delenv("MEM0_TELEMETRY", raising=False)
+        provider = Mem0LocalProvider()
+        # _ensure_memory sets the env var before importing mem0; construction
+        # against the dead endpoint may fail later, which is fine here.
+        try:
+            provider._ensure_memory(
+                __import__("basic_memory_benchmarks.models", fromlist=["RunConfig"]).RunConfig(
+                    run_id="t", dataset_id="t", dataset_path="t", corpus_dir="t", queries_path="t"
+                )
+            )
+        except Exception:
+            pass
+        assert os.environ["MEM0_TELEMETRY"] == "false"
+
+    def test_cleanup_closes_clients_and_drops_memory(self):
+        from basic_memory_benchmarks.providers.mem0_local import Mem0LocalProvider
+
+        class FakeClient:
+            closed = False
+
+            def close(self):
+                self.closed = True
+
+        class FakeStore:
+            def __init__(self):
+                self.client = FakeClient()
+
+        class FakeMemory:
+            def __init__(self):
+                self.vector_store = FakeStore()
+                self._telemetry_vector_store = FakeStore()
+
+            def delete_all(self, user_id):
+                pass
+
+        provider = Mem0LocalProvider()
+        memory = FakeMemory()
+        provider._memory = memory
+
+        from basic_memory_benchmarks.models import RunConfig
+
+        provider.cleanup(
+            RunConfig(
+                run_id="t", dataset_id="t", dataset_path="t", corpus_dir="t", queries_path="t"
+            )
+        )
+        assert memory.vector_store.client.closed
+        assert memory._telemetry_vector_store.client.closed
+        assert provider._memory is None


### PR DESCRIPTION
## Root cause (named by PR #25's error capture)

mem0 with `MEM0_TELEMETRY` on (default) opens a qdrant client at a **fixed path** (`~/.mem0/migrations_qdrant`) inside every `Memory()`. qdrant local mode permits one client per path per process; the grouped runner retains the previous provider (for `version_info`), so the lock never releases — first group succeeds, all later groups die with `Storage folder ... is already accessed`. Matrix v1 lost 24/25 LME + 30/30 ConvoMem mem0 groups. Isolated repros passed because reassignment let the old client GC — hence the ghost hunt.

## Fix

- `MEM0_TELEMETRY=false` (setdefault) before the deferred mem0 import — benchmark runs shouldn't emit telemetry anyway; operators can force-enable.
- `cleanup()` explicitly closes `vector_store`/`_telemetry_vector_store` clients and drops the reference, releasing locks even while the instance stays referenced.

## Verification

Reproduced the exact failure mode (sequential groups, retained references): fails on group 2 before, three groups clean after. 2 new unit tests; suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)