### PR TITLE
feat: stratified LongMemEval dev slices

### DIFF
--- a/src/basic_memory_benchmarks/cli.py
+++ b/src/basic_memory_benchmarks/cli.py
@@ -102,11 +102,17 @@ def convert_longmemeval(
     ),
     output_dir: Path = typer.Option(Path("benchmarks/generated/longmemeval-s"), "--output-dir"),
     max_questions: int | None = typer.Option(None, "--max-questions"),
+    stratified: bool = typer.Option(
+        False, "--stratified", help="Sample max-questions evenly across question types (seed 42)"
+    ),
+    seed: int = typer.Option(42, "--seed"),
 ) -> None:
     groups_dir, queries_path, doc_count, query_count = convert_longmemeval_to_corpus(
         dataset_path=dataset_path,
         output_dir=output_dir,
         max_questions=max_questions,
+        stratified=stratified,
+        seed=seed,
     )
     console.print(f"Groups: [cyan]{groups_dir}[/cyan] ({query_count} groups, {doc_count} docs)")
     console.print(f"Queries: [cyan]{queries_path}[/cyan] ({query_count})")

--- a/src/basic_memory_benchmarks/converters/longmemeval_to_corpus.py
+++ b/src/basic_memory_benchmarks/converters/longmemeval_to_corpus.py
@@ -14,6 +14,8 @@ ingested by a provider distinguishes evidence from filler.
 from __future__ import annotations
 
 import json
+import random
+from collections import defaultdict
 from pathlib import Path
 
 from basic_memory_benchmarks.datasets.longmemeval import load_longmemeval_dataset
@@ -53,14 +55,43 @@ def convert_longmemeval_to_corpus(
     dataset_path: Path,
     output_dir: Path,
     max_questions: int | None = None,
+    stratified: bool = False,
+    seed: int = 42,
 ) -> tuple[Path, Path, int, int]:
     """Convert LongMemEval-S into per-question corpora + query manifest.
+
+    ``max_questions`` with ``stratified=False`` takes the file-order prefix
+    (the file is sorted by question type, so small prefixes are single-type —
+    fine for smoke tests, misleading for category comparisons).
+    ``stratified=True`` samples evenly across the six question types with a
+    fixed seed and records the composition in sampling.json.
 
     Returns:
         groups_dir, queries_path, doc_count, query_count
     """
     entries = load_longmemeval_dataset(dataset_path)
-    if max_questions is not None:
+    sampling_note: dict | None = None
+    if max_questions is not None and stratified:
+        by_type: dict[str, list[dict]] = defaultdict(list)
+        for entry in entries:
+            by_type[str(entry["question_type"])].append(entry)
+        rng = random.Random(seed)
+        per_type = max(1, max_questions // len(by_type))
+        sampled: list[dict] = []
+        composition: dict[str, int] = {}
+        for question_type, members in sorted(by_type.items()):
+            members.sort(key=lambda e: str(e["question_id"]))
+            take = min(per_type, len(members))
+            sampled.extend(rng.sample(members, take))
+            composition[question_type] = take
+        entries = sampled
+        sampling_note = {
+            "seed": seed,
+            "max_questions": max_questions,
+            "per_type": per_type,
+            "composition": composition,
+        }
+    elif max_questions is not None:
         entries = entries[:max_questions]
 
     groups_dir = output_dir / "groups"
@@ -130,5 +161,9 @@ def convert_longmemeval_to_corpus(
 
     queries_path = output_dir / "queries.json"
     queries_path.write_text(json.dumps(all_queries, indent=2), encoding="utf-8")
+    if sampling_note is not None:
+        (output_dir / "sampling.json").write_text(
+            json.dumps(sampling_note, indent=2), encoding="utf-8"
+        )
 
     return groups_dir, queries_path, doc_count, len(all_queries)

--- a/tests/converters/test_longmemeval_converter.py
+++ b/tests/converters/test_longmemeval_converter.py
@@ -130,3 +130,53 @@ class TestConvertLongMemEval:
             dataset_path=dataset, output_dir=tmp_path / "out", max_questions=2
         )
         assert query_count == 2
+
+
+class TestStratifiedSlice:
+    def test_stratified_covers_types_evenly(self, tmp_path):
+        entries = []
+        for t in ["single-session-user", "multi-session", "temporal-reasoning"]:
+            for i in range(10):
+                entries.append(_entry(f"{t[:4]}{i}", question_type=t))
+        dataset = _write_dataset(tmp_path, entries)
+
+        _, queries_path, _, count = convert_longmemeval_to_corpus(
+            dataset_path=dataset,
+            output_dir=tmp_path / "out",
+            max_questions=9,
+            stratified=True,
+        )
+
+        import collections
+
+        queries = json.loads(queries_path.read_text())
+        by_type = collections.Counter(q["category"] for q in queries)
+        assert count == 9
+        assert all(v == 3 for v in by_type.values())
+        sampling = json.loads((tmp_path / "out" / "sampling.json").read_text())
+        assert sampling["seed"] == 42
+
+    def test_stratified_deterministic(self, tmp_path):
+        entries = [_entry(f"q{i}", question_type="multi-session") for i in range(20)]
+        dataset = _write_dataset(tmp_path, entries)
+        ids = []
+        for run in range(2):
+            _, qp, _, _ = convert_longmemeval_to_corpus(
+                dataset_path=dataset,
+                output_dir=tmp_path / f"out{run}",
+                max_questions=5,
+                stratified=True,
+            )
+            ids.append([q["id"] for q in json.loads(qp.read_text())])
+        assert ids[0] == ids[1]
+
+    def test_prefix_mode_unchanged(self, tmp_path):
+        entries = [_entry(f"q{i}") for i in range(5)]
+        dataset = _write_dataset(tmp_path, entries)
+        _, qp, _, count = convert_longmemeval_to_corpus(
+            dataset_path=dataset,
+            output_dir=tmp_path / "out",
+            max_questions=2,
+        )
+        assert count == 2
+        assert [q["id"] for q in json.loads(qp.read_text())] == ["q0", "q1"]


### PR DESCRIPTION
`--max-questions` takes the file-order prefix, and the dataset is sorted by question type — so dev25 was 25× single-session-user. Fine for smoke tests; misleading for category comparisons (matrix v1's LME QA numbers cover one category only).

`convert longmemeval --stratified` samples evenly across the six question types (fixed seed, composition recorded in `sampling.json`). Prefix behavior unchanged without the flag.

3 new tests; suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)