### PR TITLE
fix: surface result titles in QA context assembly

### DIFF
--- a/src/basic_memory_benchmarks/scoring/qa.py
+++ b/src/basic_memory_benchmarks/scoring/qa.py
@@ -140,7 +140,11 @@ def assemble_context(hits: list[SearchHit], max_chars: int = CONTEXT_MAX_CHARS) 
             if not snippet:
                 break
         source = hit.source_doc_id or hit.source_path or "unknown"
-        sections.append(f"[Memory {rank} | source: {source}]\n{snippet}")
+        title = (hit.metadata or {}).get("title")
+        header = f"[Memory {rank} | source: {source}]"
+        if title and str(title) not in snippet:
+            header = f"[Memory {rank} | source: {source} | {title}]"
+        sections.append(f"{header}\n{snippet}")
         used += len(snippet)
         if used >= max_chars:
             break

--- a/tests/test_qa_scoring.py
+++ b/tests/test_qa_scoring.py
@@ -350,3 +350,31 @@ class TestContextBudgetOverride:
             max_context_chars=30_000,
         )
         assert answerer.prompts[0].count("z") == 30_000
+
+
+class TestHitTitleInContext:
+    def test_title_metadata_lands_in_header(self):
+        from basic_memory_benchmarks.models import SearchHit
+        from basic_memory_benchmarks.scoring.qa import assemble_context
+
+        hit = SearchHit(
+            source_doc_id="doc-a",
+            text="- **Melanie:** I hiked yesterday!",
+            score=1.0,
+            metadata={"title": "locomo-c00-s18 (3:01 pm on 20 October, 2023)"},
+        )
+        ctx = assemble_context([hit])
+        assert "| locomo-c00-s18 (3:01 pm on 20 October, 2023)]" in ctx
+
+    def test_title_skipped_when_already_in_text(self):
+        from basic_memory_benchmarks.models import SearchHit
+        from basic_memory_benchmarks.scoring.qa import assemble_context
+
+        hit = SearchHit(
+            source_doc_id="doc-a",
+            text="# Chat session at 8 May 2023\nfull body",
+            score=1.0,
+            metadata={"title": "Chat session at 8 May 2023"},
+        )
+        ctx = assemble_context([hit])
+        assert ctx.count("Chat session at 8 May 2023") == 1


### PR DESCRIPTION
## The finding (LoCoMo v2 q300)

The session-date fix lifted multi_hop to **0.57 (mem0)** and **0.52 (grep)** — but **bm-local stayed at 0.06**. Structural asymmetry: BM returns bullet-level matched chunks as hit text; precise, but they strip the document context where the session date lives. grep returns doc heads (date included); mem0 stores whole docs. Only BM lost temporal anchoring.

## Fix

BM's search results already return the title (which now carries the session date). The provider passes it through hit metadata; context assembly adds it to the section header when not already present in the snippet. Provider-neutral — assembly uses whatever any provider returns.

The underlying product gap (BM chunks lack document-level context) is queued as the first basic-memory Phase 2 change.

2 new tests; suite green (105), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)