### PR TITLE
fix: carry BM result title into hit metadata (+45pts multi_hop/temporal QA)

### DIFF
--- a/src/basic_memory_benchmarks/providers/bm_local.py
+++ b/src/basic_memory_benchmarks/providers/bm_local.py
@@ -347,6 +347,36 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
             name = name[:-3]
         return name
 
+    @classmethod
+    def _row_to_hit(cls, row: dict[str, Any]) -> SearchHit:
+        """Normalize a search_notes result row into a SearchHit.
+
+        Carries the document title into hit metadata: BM's matched_chunk is a
+        single bullet that strips document context, but the title holds it (for
+        LoCoMo/LongMemEval the session date lives there, e.g.
+        ``locomo-c00-s07 (4:33 pm on 12 July, 2023)``). Surfacing it lets the QA
+        assembler anchor relative dates ("two days ago") that bullets alone
+        leave unresolvable.
+        """
+        metadata_raw = row.get("metadata")
+        metadata: dict[str, Any]
+        if isinstance(metadata_raw, dict):
+            metadata = cast(dict[str, Any], metadata_raw)
+        else:
+            metadata = {}
+        if row.get("title"):
+            metadata = {**metadata, "title": str(row["title"])}
+        return SearchHit(
+            id=str(
+                row.get("entity_id") or row.get("observation_id") or row.get("relation_id") or ""
+            ),
+            source_doc_id=cls._doc_id_from_item(row),
+            source_path=row.get("file_path") or row.get("permalink"),
+            text=row.get("matched_chunk") or row.get("content"),
+            score=float(row.get("score", 0.0) or 0.0),
+            metadata=metadata,
+        )
+
     def search(self, query: str, limit: int, run_config: RunConfig) -> list[SearchHit]:
         if self._mcp is None:
             raise RuntimeError("bm-local MCP session is not initialized")
@@ -369,27 +399,7 @@ class BasicMemoryLocalProvider(BenchmarkProvider):
         for row in rows or []:
             if not isinstance(row, dict):
                 continue
-            metadata_raw = row.get("metadata")
-            metadata: dict[str, Any]
-            if isinstance(metadata_raw, dict):
-                metadata = cast(dict[str, Any], metadata_raw)
-            else:
-                metadata = {}
-            hits.append(
-                SearchHit(
-                    id=str(
-                        row.get("entity_id")
-                        or row.get("observation_id")
-                        or row.get("relation_id")
-                        or ""
-                    ),
-                    source_doc_id=self._doc_id_from_item(row),
-                    source_path=row.get("file_path") or row.get("permalink"),
-                    text=row.get("matched_chunk") or row.get("content"),
-                    score=float(row.get("score", 0.0) or 0.0),
-                    metadata=metadata,
-                )
-            )
+            hits.append(self._row_to_hit(row))
         return hits
 
     def cleanup(self, run_config: RunConfig) -> None:

--- a/tests/providers/test_bm_local_provider.py
+++ b/tests/providers/test_bm_local_provider.py
@@ -144,3 +144,33 @@ def test_resolve_bm_command_prefix_local_path_missing_raises() -> None:
     )
     with pytest.raises(ValueError, match="--bm-local-path not found"):
         BasicMemoryLocalProvider._resolve_bm_command_prefix(run_config)
+
+
+def test_row_to_hit_surfaces_title_for_date_anchoring() -> None:
+    """The document title (carrying the session date) reaches hit metadata."""
+    from basic_memory_benchmarks.providers.bm_local import BasicMemoryLocalProvider
+
+    row = {
+        "title": "locomo-c00-s07 (4:33 pm on 12 July, 2023)",
+        "entity_id": 7,
+        "file_path": "locomo-c00-s07.md",
+        "matched_chunk": "- **Caroline:** I went to an LGBTQ conference two days ago",
+        "content": "# Chat session at 4:33 pm on 12 July, 2023\n...",
+        "score": 1.13,
+        "metadata": {"note_type": "note"},
+    }
+    hit = BasicMemoryLocalProvider._row_to_hit(row)
+    assert hit.metadata["title"] == "locomo-c00-s07 (4:33 pm on 12 July, 2023)"
+    assert hit.metadata["note_type"] == "note"  # existing metadata preserved
+    assert hit.source_doc_id == "locomo-c00-s07"
+    assert "two days ago" in (hit.text or "")
+    assert hit.score == 1.13
+
+
+def test_row_to_hit_without_title_omits_key() -> None:
+    from basic_memory_benchmarks.providers.bm_local import BasicMemoryLocalProvider
+
+    hit = BasicMemoryLocalProvider._row_to_hit(
+        {"entity_id": 1, "matched_chunk": "text", "file_path": "doc.md"}
+    )
+    assert "title" not in hit.metadata


### PR DESCRIPTION
## Summary

`bm_local` discarded the `title` field that `search_notes` returns. PR #29 added title handling to the QA *assembler* but never to the *provider*, so `metadata["title"]` was always empty — dead code.

BM returns a dated title per result (`locomo-c00-s07 (4:33 pm on 12 July, 2023)`) alongside the bullet-level `matched_chunk`. The bullet strips document context, so relative-date answers ("two days ago", "last Saturday") had no anchor and the answerer abstained or hedged. Surfacing the title — which the assembler already knows how to use — restores it.

**Provider-faithful, not gaming:** the title is data BM genuinely returns; the harness was *under-representing* BM by dropping it. Each provider's hits still carry what that provider actually returns.

## Measured impact

LoCoMo multi_hop+temporal subset (n=82, identical BM #994 worktree, only the harness title passthrough differs):

| category | before | after |
|---|---|---|
| multi_hop | 5/63 | **38/63** |
| temporal | 3/19 | **7/19** |
| combined | 8/82 (0.098) | **45/82 (0.549)** |

## Testing

Refactored hit construction into `_row_to_hit` for direct unit testing; 2 new tests (title surfaced + preserved alongside existing metadata; absent-title omits the key). Full suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)