### PR TITLE
fix: include per-group causes when all grouped runs fail

### DIFF
--- a/src/basic_memory_benchmarks/runner.py
+++ b/src/basic_memory_benchmarks/runner.py
@@ -166,7 +166,13 @@ def _execute_provider_grouped(
                 pass
 
     if last_provider is None:
-        raise RuntimeError(f"All {len(failed_groups)} groups failed for provider {provider_name}")
+        # Surface the first captured errors: an opaque "all failed" with no
+        # cause is undiagnosable after a multi-hour run.
+        detail = "; ".join(f"{gid}: {msg}" for gid, msg in sorted(failed_group_errors.items()))
+        raise RuntimeError(
+            f"All {len(failed_groups)} groups failed for provider {provider_name}"
+            + (f" — {detail}" if detail else "")
+        )
 
     group_metadata: dict[str, str] = {
         "grouped_mode": "true",

--- a/tests/test_runner_grouped.py
+++ b/tests/test_runner_grouped.py
@@ -298,3 +298,26 @@ class TestGroupErrorCapture:
         assert meta["failed_group_count"] == "2"
         assert "qb: RuntimeError: boom in qb" in meta["failed_group_error_0"]
         assert "qc: RuntimeError: boom in qc" in meta["failed_group_error_1"]
+
+
+class TestAllGroupsFailedDetail:
+    def test_all_failed_error_includes_group_causes(self, tmp_path):
+        """When every group fails, the raised error must name the causes.
+
+        An opaque 'all N groups failed' with no reason is undiagnosable after
+        a long run (hit during the supermemory integration).
+        """
+        corpus_root, queries_path = _setup_grouped_corpus(tmp_path, ["qa", "qb"])
+        RecordingProvider.fail_groups = {"qa", "qb"}
+        config = _run_config(tmp_path, corpus_root, queries_path)
+        config = config.model_copy(update={"allow_provider_skip": False})
+
+        with pytest.raises(RuntimeError, match="All 2 groups failed") as excinfo:
+            run_retrieval(
+                run_config=config,
+                dataset=_provenance(),
+                provider_factory=lambda name: RecordingProvider(),
+            )
+        message = str(excinfo.value)
+        assert "qa: RuntimeError: boom in qa" in message
+        assert "qb: RuntimeError: boom in qb" in message


### PR DESCRIPTION
The all-groups-failed path raised an opaque `All N groups failed for provider X` and returned *before* the success path wrote the `failed_group_error_*` metadata — so the cause was lost. Hit this diagnosing supermemory (`All 12 groups failed` with no reason in the artifact; the real cause was docs stuck at `embedding`). The error now appends the first captured per-group causes. 1 new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)