### PR TITLE
feat: judge-only re-score (run rejudge) for safe judge calibration

### DIFF
--- a/src/basic_memory_benchmarks/cli.py
+++ b/src/basic_memory_benchmarks/cli.py
@@ -24,7 +24,12 @@ from basic_memory_benchmarks.reporting.compare import (
     compare_provider_metric,
     load_retrieval_summary,
 )
-from basic_memory_benchmarks.runner import run_judge, run_qa_stage, run_retrieval
+from basic_memory_benchmarks.runner import (
+    run_judge,
+    run_qa_stage,
+    run_rejudge_stage,
+    run_retrieval,
+)
 from basic_memory_benchmarks.utils import sha256_file
 
 app = typer.Typer(help="Basic Memory benchmark suite")
@@ -225,6 +230,18 @@ def run_qa_command(
     )
     console.print(f"QA run complete: [green]{out}[/green]")
     console.print(f"See [cyan]{out / 'qa-summary.json'}[/cyan]")
+
+
+@run_app.command("rejudge")
+def run_rejudge_command(
+    run_dir: Path = typer.Option(..., "--run-dir"),
+    judge: str = typer.Option("claude:claude-sonnet-4-6", "--judge"),
+    max_workers: int = typer.Option(4, "--max-workers"),
+) -> None:
+    """Re-judge stored QA answers (no regeneration); reports verdict flips."""
+    out = run_rejudge_stage(run_dir=run_dir, judge_spec=judge, max_workers=max_workers)
+    console.print(f"Re-judge complete: [green]{out}[/green]")
+    console.print(f"Flips: [cyan]{out / 'qa-rejudge-flips.json'}[/cyan]")
 
 
 @run_app.command("judge")

--- a/src/basic_memory_benchmarks/runner.py
+++ b/src/basic_memory_benchmarks/runner.py
@@ -352,6 +352,66 @@ def run_qa_stage(
     return run_dir
 
 
+def run_rejudge_stage(
+    *,
+    run_dir: Path,
+    judge_spec: str,
+    max_workers: int = 4,
+) -> Path:
+    """Re-judge stored QA answers with a (possibly different) judge.
+
+    Reads per-query-qa.jsonl, re-runs only the judge on each stored generated
+    answer, and writes per-query-qa-rejudge.jsonl, qa-rejudge-summary.json (per
+    provider), and qa-rejudge-flips.json (cases whose verdict changed) for
+    judge-calibration review. The original QA artifacts are left untouched.
+    """
+    from basic_memory_benchmarks.llm.runners import create_runner
+    from basic_memory_benchmarks.models import QACaseResult
+    from basic_memory_benchmarks.scoring.qa import rejudge_cases
+
+    qa_path = run_dir / "per-query-qa.jsonl"
+    if not qa_path.exists():
+        raise FileNotFoundError(f"Missing QA artifact: {qa_path}")
+
+    cases_by_provider: dict[str, list[QACaseResult]] = {}
+    with qa_path.open("r", encoding="utf-8") as file:
+        for line in file:
+            line = line.strip()
+            if line:
+                case = QACaseResult.model_validate(json.loads(line))
+                cases_by_provider.setdefault(case.provider, []).append(case)
+
+    judge = create_runner(judge_spec)
+    all_rejudged = []
+    summaries = []
+    all_flips = []
+    for provider, cases in cases_by_provider.items():
+        rejudged, summary, flips = rejudge_cases(cases, judge=judge, max_workers=max_workers)
+        all_rejudged.extend(rejudged)
+        summaries.append(summary)
+        all_flips.extend(flips)
+
+    rejudge_jsonl = run_dir / "per-query-qa-rejudge.jsonl"
+    with rejudge_jsonl.open("w", encoding="utf-8") as file:
+        for case in all_rejudged:
+            file.write(json.dumps(case.model_dump(mode="json"), sort_keys=True) + "\n")
+
+    (run_dir / "qa-rejudge-summary.json").write_text(
+        json.dumps(
+            {"judge": judge_spec, "providers": [s.model_dump(mode="json") for s in summaries]},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "qa-rejudge-flips.json").write_text(
+        json.dumps(
+            {"judge": judge_spec, "flip_count": len(all_flips), "flips": all_flips}, indent=2
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
 def run_judge(
     *,
     run_dir: Path,

--- a/src/basic_memory_benchmarks/scoring/qa.py
+++ b/src/basic_memory_benchmarks/scoring/qa.py
@@ -227,6 +227,105 @@ def _score_case(
         )
 
 
+def _rejudge_case(case: QACaseResult, judge: LLMRunner) -> QACaseResult:
+    """Re-judge one stored case against its generated answer (no regeneration).
+
+    Errored cases (no generated answer) are returned unchanged. The answerer
+    fields are preserved; only the verdict and judge_model are updated.
+    """
+    if case.error:
+        return case
+    try:
+        verdict = judge.complete(
+            build_judge_prompt(case.question, case.expected_answer, case.generated_answer)
+        )
+        correct, reason = parse_judge_verdict(verdict.text)
+    except (LLMRunnerError, ValueError, json.JSONDecodeError) as exc:
+        return case.model_copy(update={"error": f"rejudge failed: {exc}"})
+    return case.model_copy(
+        update={"correct": correct, "judge_reason": reason, "judge_model": judge.spec}
+    )
+
+
+def rejudge_cases(
+    cases: list[QACaseResult],
+    *,
+    judge: LLMRunner,
+    max_workers: int = 4,
+) -> tuple[list[QACaseResult], QASummary, list[dict]]:
+    """Re-judge stored QA cases with a (possibly different) judge.
+
+    Returns the re-judged cases, a summary, and the list of verdict flips
+    (cases whose correctness changed) for calibration review.
+    """
+    if not cases:
+        return (
+            [],
+            QASummary(
+                provider="rejudge",
+                answer_model="stored",
+                judge_model=judge.spec,
+                total_cases=0,
+                correct_count=0,
+                error_count=0,
+                abstain_count=0,
+                accuracy=0.0,
+                skipped_reason="No stored cases to re-judge",
+            ),
+            [],
+        )
+
+    provider = cases[0].provider
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        rejudged = list(pool.map(lambda c: _rejudge_case(c, judge), cases))
+
+    flips = [
+        {
+            "query_id": new.query_id,
+            "category": new.category,
+            "question": new.question,
+            "expected_answer": new.expected_answer,
+            "generated_answer": new.generated_answer,
+            "was_correct": old.correct,
+            "now_correct": new.correct,
+            "old_reason": old.judge_reason,
+            "new_reason": new.judge_reason,
+        }
+        for old, new in zip(cases, rejudged)
+        if old.correct != new.correct
+    ]
+    summary = _summarize_cases(rejudged, provider=provider, answer_model="stored", judge=judge)
+    return rejudged, summary, flips
+
+
+def _summarize_cases(
+    case_results: list[QACaseResult],
+    *,
+    provider: str,
+    answer_model: str,
+    judge: LLMRunner,
+) -> QASummary:
+    by_category: dict[str, QACategoryMetrics] = {}
+    for case in case_results:
+        bucket = by_category.setdefault(case.category, QACategoryMetrics())
+        bucket.total += 1
+        bucket.correct += 1 if case.correct else 0
+    for bucket in by_category.values():
+        bucket.accuracy = bucket.correct / bucket.total if bucket.total else 0.0
+    correct_count = sum(1 for case in case_results if case.correct)
+    return QASummary(
+        provider=provider,
+        answer_model=answer_model,
+        judge_model=judge.spec,
+        total_cases=len(case_results),
+        correct_count=correct_count,
+        error_count=sum(1 for case in case_results if case.error),
+        abstain_count=sum(1 for case in case_results if case.abstained),
+        accuracy=correct_count / len(case_results) if case_results else 0.0,
+        by_category=by_category,
+    )
+
+
 def run_qa(
     rows: list[PerQueryRetrievalResult],
     *,

--- a/tests/test_qa_scoring.py
+++ b/tests/test_qa_scoring.py
@@ -378,3 +378,84 @@ class TestHitTitleInContext:
         )
         ctx = assemble_context([hit])
         assert ctx.count("Chat session at 8 May 2023") == 1
+
+
+class TestRejudge:
+    def _case(self, qid, correct, generated="ans", error=None, category="single_hop"):
+        from basic_memory_benchmarks.models import QACaseResult
+
+        return QACaseResult(
+            provider="bm-local",
+            query_id=qid,
+            category=category,
+            question="Q?",
+            expected_answer="gold",
+            generated_answer=generated,
+            abstained=False,
+            correct=correct,
+            judge_reason="orig",
+            answer_model="claude:haiku",
+            judge_model="claude:sonnet",
+            answer_latency_ms=1.0,
+            answer_input_tokens=1,
+            answer_output_tokens=1,
+            error=error,
+        )
+
+    def test_rejudge_flips_and_summary(self):
+        from basic_memory_benchmarks.scoring.qa import rejudge_cases
+
+        cases = [self._case("q1", correct=False), self._case("q2", correct=True)]
+        # New judge flips q1 to correct, keeps q2 correct.
+        judge = FakeRunner(
+            {},
+            default='{"correct": true, "reason": "incomplete gold is fine"}',
+        )
+        rejudged, summary, flips = rejudge_cases(cases, judge=judge, max_workers=1)
+
+        assert summary.correct_count == 2
+        assert summary.accuracy == 1.0
+        assert len(flips) == 1
+        assert flips[0]["query_id"] == "q1"
+        assert flips[0]["was_correct"] is False and flips[0]["now_correct"] is True
+        # answerer fields preserved; judge_model updated.
+        assert rejudged[0].judge_model == "fake:test"
+        assert rejudged[0].answer_model == "claude:haiku"
+
+    def test_rejudge_preserves_errored_cases(self):
+        from basic_memory_benchmarks.scoring.qa import rejudge_cases
+
+        cases = [self._case("q1", correct=False, error="llm died")]
+        judge = FakeRunner({}, default='{"correct": true, "reason": "x"}')
+        rejudged, summary, flips = rejudge_cases(cases, judge=judge, max_workers=1)
+        # Errored case is untouched (no generated answer to judge).
+        assert rejudged[0].correct is False
+        assert rejudged[0].error == "llm died"
+        assert flips == []
+
+    def test_rejudge_empty(self):
+        from basic_memory_benchmarks.scoring.qa import rejudge_cases
+
+        judge = FakeRunner({}, default='{"correct": true, "reason": "x"}')
+        rejudged, summary, flips = rejudge_cases([], judge=judge)
+        assert rejudged == [] and flips == []
+        assert summary.skipped_reason is not None
+
+    def test_rejudge_stage_artifacts(self, tmp_path, monkeypatch):
+        import json as _json
+
+        from basic_memory_benchmarks import runner as runner_module
+
+        case = self._case("q1", correct=False)
+        (tmp_path / "per-query-qa.jsonl").write_text(
+            _json.dumps(case.model_dump(mode="json")) + "\n", encoding="utf-8"
+        )
+        fake = FakeRunner({}, default='{"correct": true, "reason": "flipped"}')
+        monkeypatch.setattr("basic_memory_benchmarks.llm.runners.create_runner", lambda spec: fake)
+        runner_module.run_rejudge_stage(run_dir=tmp_path, judge_spec="fake:test", max_workers=1)
+
+        assert (tmp_path / "per-query-qa-rejudge.jsonl").exists()
+        summary = _json.loads((tmp_path / "qa-rejudge-summary.json").read_text())
+        assert summary["providers"][0]["correct_count"] == 1
+        flips = _json.loads((tmp_path / "qa-rejudge-flips.json").read_text())
+        assert flips["flip_count"] == 1


### PR DESCRIPTION
Adds `run rejudge` — re-judges stored QA answers without regenerating them, reporting verdict **flips** vs the original. Enabling infrastructure for judge calibration, the highest-leverage remaining lever for credible numbers.

**Why:** LoCoMo gold answers are documented-incomplete (Penfield audit), and the current judge wrongly fails correct-but-more-complete answers — e.g. a recipes answer containing *both* gold items plus an extra retrieved one is marked 'hallucinated'. Fixing the rubric needs careful flip-validation (the audit also warns judges run too lenient), and this makes that A/B cheap and safe.

- `rejudge_cases()` re-runs only the judge on stored cases; preserves answerer fields + errored cases; returns flips.
- `run rejudge` CLI writes `per-query-qa-rejudge.jsonl`, `qa-rejudge-summary.json`, `qa-rejudge-flips.json`; original artifacts untouched.

**Validated:** re-judging a 35q run with the *same* judge reproduces verdicts with **0 flips** (deterministic) → flips from a new rubric are signal. 4 new tests; suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)