### PR TITLE
feat: judge rubric handles incomplete gold answers

### DIFF
--- a/src/basic_memory_benchmarks/scoring/qa.py
+++ b/src/basic_memory_benchmarks/scoring/qa.py
@@ -53,22 +53,28 @@ Instructions:
 Answer:"""
 
 JUDGE_PROMPT_TEMPLATE = """\
-You are grading a question-answering system. Compare the candidate answer to the
-gold answer.
+You are grading a question-answering system against a reference (gold) answer.
+The gold answer may be INCOMPLETE: it lists the key fact(s) the candidate must
+cover, but is not necessarily an exhaustive list.
 
 Question: {question}
 Gold answer: {gold}
 Candidate answer: {candidate}
 
-Grading rules:
-- correct = true only if the candidate states the same core fact(s) as the gold
-  answer. Paraphrase, formatting, and extra correct detail are fine.
-- If the gold answer indicates the information is not available (e.g. "not
-  mentioned", "no information"), the candidate is correct only if it also
-  declines to answer (e.g. "{abstain}").
-- A candidate that declines to answer when the gold answer contains a real fact
-  is incorrect.
-- Partial answers missing a key fact are incorrect.
+Mark correct = true when BOTH hold:
+- The candidate states every key fact in the gold answer (paraphrase and
+  formatting differences are fine).
+- The candidate does not contradict the gold answer.
+Additional specific facts in the candidate beyond the gold answer are NOT errors;
+do not treat them as hallucination unless they directly contradict the gold.
+
+Mark correct = false when ANY holds:
+- A key fact from the gold answer is missing from the candidate.
+- The candidate contradicts the gold answer.
+- The gold answer indicates the information is unavailable (e.g. "not
+  mentioned", "no information") but the candidate asserts a fact; OR the gold
+  answer contains a real fact but the candidate declines to answer (e.g.
+  "{abstain}").
 
 Reply with only a JSON object: {{"correct": true or false, "reason": "<one sentence>"}}"""
 

--- a/tests/test_qa_scoring.py
+++ b/tests/test_qa_scoring.py
@@ -81,6 +81,14 @@ class TestPrompts:
         assert "gold fact" in prompt
         assert "candidate fact" in prompt
 
+    def test_judge_prompt_allows_incomplete_gold(self):
+        # The rubric must tell the judge gold answers may be incomplete and that
+        # extra non-contradicting facts are not errors (LoCoMo gold answers are
+        # documented-incomplete; the prior rubric over-failed correct answers).
+        prompt = build_judge_prompt("Q?", "gold", "candidate")
+        assert "INCOMPLETE" in prompt
+        assert "not errors" in prompt.lower()
+
 
 class TestParseJudgeVerdict:
     def test_plain_json(self):


### PR DESCRIPTION
**Drew-approved** judge rubric change. LoCoMo gold answers are documented-incomplete (Penfield audit); the prior rubric over-failed correct answers (a recipes answer with both gold items + an extra retrieved one was judged 'hallucinated').

New rubric: gold may be incomplete; candidate must state every key gold fact and not contradict it; additional non-contradicting facts are NOT errors. Retains strictness on missing facts + abstention.

**Validated** via `run rejudge` (#35) on mcombined-locomo-q300: **0.611 → 0.641**. The +3pts is *more-accurate* judging, not leniency — full review of all 15 flips: ~10-11/12 fail→pass genuinely correct; **2/3 pass→fail correctly catch false positives the old judge passed** (hedged 'winning at something'; an answer missing a gold fact); 1 edge-case regression on a malformed 'cannot be determined' gold. Applied identically to all providers → relative comparisons preserved.

Published numbers regenerated under this rubric in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)