### PR TITLE
fix: judge rubric must handle unanswerable questions before fact-matching

### DIFF
--- a/src/basic_memory_benchmarks/scoring/qa.py
+++ b/src/basic_memory_benchmarks/scoring/qa.py
@@ -54,12 +54,21 @@ Answer:"""
 
 JUDGE_PROMPT_TEMPLATE = """\
 You are grading a question-answering system against a reference (gold) answer.
-The gold answer may be INCOMPLETE: it lists the key fact(s) the candidate must
-cover, but is not necessarily an exhaustive list.
 
 Question: {question}
 Gold answer: {gold}
 Candidate answer: {candidate}
+
+FIRST, handle the unanswerable case. If the gold answer indicates the
+information is NOT available (e.g. "no information", "not mentioned", "cannot
+be determined"), then judge ONLY on whether the candidate declines:
+- correct = true if the candidate also declines / abstains (e.g. "{abstain}").
+- correct = false if the candidate asserts a specific factual answer.
+Do not apply the fact-matching rules below to this case.
+
+OTHERWISE (the gold answer contains real facts), the gold answer may be
+INCOMPLETE: it lists the key fact(s) the candidate must cover, but is not
+necessarily an exhaustive list.
 
 Mark correct = true when BOTH hold:
 - The candidate states every key fact in the gold answer (paraphrase and
@@ -71,10 +80,8 @@ do not treat them as hallucination unless they directly contradict the gold.
 Mark correct = false when ANY holds:
 - A key fact from the gold answer is missing from the candidate.
 - The candidate contradicts the gold answer.
-- The gold answer indicates the information is unavailable (e.g. "not
-  mentioned", "no information") but the candidate asserts a fact; OR the gold
-  answer contains a real fact but the candidate declines to answer (e.g.
-  "{abstain}").
+- The candidate declines to answer (e.g. "{abstain}") even though the gold
+  answer contains a real fact.
 
 Reply with only a JSON object: {{"correct": true or false, "reason": "<one sentence>"}}"""
 

--- a/tests/test_qa_scoring.py
+++ b/tests/test_qa_scoring.py
@@ -89,6 +89,17 @@ class TestPrompts:
         assert "INCOMPLETE" in prompt
         assert "not errors" in prompt.lower()
 
+    def test_judge_prompt_handles_unanswerable_before_fact_matching(self):
+        # Abstention/unanswerable cases (ConvoMem abstention, LoCoMo adversarial)
+        # must be judged FIRST on whether the candidate declines — otherwise the
+        # fact-matching rules wrongly fail a correct "I don't know" against a
+        # "no information" gold (regression caught during number regeneration).
+        prompt = build_judge_prompt("Q?", "gold", "candidate")
+        first = prompt.split("OTHERWISE")[0]
+        assert "not available" in first.lower()
+        assert ABSTAIN_SENTINEL in first
+        assert "declines" in first.lower()
+
 
 class TestParseJudgeVerdict:
     def test_plain_json(self):


### PR DESCRIPTION
**Regression fix** caught during number regeneration. The incomplete-gold rubric (#36) dropped the positive abstention clause, so the judge wrongly **failed** all 67 ConvoMem abstention cases (candidate "I don't know" vs "no information to answer" gold) → ConvoMem bm 0.792→0.701. The LoCoMo q300 calibration that validated #36 *excludes* abstention cases — a validation blind spot.

Fix: judge the unanswerable case FIRST (gold indicates info unavailable → correct iff candidate also declines), before fact-matching. Re-validated with abstention: ConvoMem **0.701→0.755** (recovered), LoCoMo mcombined holds **0.641**. 1 new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)