### PR TITLE
feat: attribute QA failures to retrieval vs answerer (run diagnose)

### DIFF
--- a/src/basic_memory_benchmarks/cli.py
+++ b/src/basic_memory_benchmarks/cli.py
@@ -25,6 +25,7 @@ from basic_memory_benchmarks.reporting.compare import (
     load_retrieval_summary,
 )
 from basic_memory_benchmarks.runner import (
+    run_diagnose_stage,
     run_judge,
     run_qa_stage,
     run_rejudge_stage,
@@ -242,6 +243,49 @@ def run_review_command(
     out = run_review_stage(run_dir=run_dir, source=source)
     console.print(f"Review report: [green]{out}[/green]")
     console.print(f"Open it: [cyan]open {out}[/cyan]")
+
+
+@run_app.command("diagnose")
+def run_diagnose_command(
+    run_dir: Path = typer.Option(..., "--run-dir"),
+    source: str = typer.Option("auto", "--source", help="qa | rejudge | auto"),
+    recall_field: str = typer.Option(
+        "recall_at_10", "--recall-field", help="recall_at_5 | recall_at_10"
+    ),
+) -> None:
+    """Attribute QA failures to retrieval vs the answerer (per provider).
+
+    Separates "retrieved but unused" (the fixed answerer's fault, identical
+    across providers) from "truly missed" (a real retrieval failure), so QA
+    accuracy can be read honestly against the retrieval ceiling.
+    """
+    import json
+
+    from rich.table import Table
+
+    out = run_diagnose_stage(run_dir=run_dir, source=source, recall_field=recall_field)
+    payload = json.loads(out.read_text(encoding="utf-8"))
+
+    table = Table(title=f"Failure attribution — {run_dir.name} ({payload['source']})")
+    table.add_column("provider")
+    table.add_column("answerable", justify="right")
+    table.add_column("QA acc", justify="right")
+    table.add_column("retr. ceiling", justify="right")
+    table.add_column("answerer gap", justify="right")
+    table.add_column("retrieval gap", justify="right")
+    table.add_column("of fails: answerer", justify="right")
+    for prov in payload["providers"]:
+        table.add_row(
+            prov["provider"],
+            str(prov["answerable"]),
+            f"{prov['qa_accuracy']:.3f}",
+            f"{prov['retrieval_ceiling']:.3f}",
+            f"{prov['answerer_gap']:.3f}",
+            f"{prov['retrieval_gap']:.3f}",
+            f"{prov['answerer_failure_share']:.0%}",
+        )
+    console.print(table)
+    console.print(f"Wrote [green]{out}[/green]")
 
 
 @run_app.command("rejudge")

--- a/src/basic_memory_benchmarks/models.py
+++ b/src/basic_memory_benchmarks/models.py
@@ -145,6 +145,46 @@ class QASummary(BaseModel):
     skipped_reason: str | None = None
 
 
+class CategoryDiagnosis(BaseModel):
+    """Per-category answerer-vs-retrieval attribution of QA failures."""
+
+    answerable: int = 0
+    correct: int = 0
+    retrieved_but_unused: int = 0  # gold retrieved, answer still wrong → answerer's fault
+    truly_missed: int = 0  # gold not retrieved → retrieval's fault
+
+
+class ProviderDiagnosis(BaseModel):
+    """Attributes each provider's QA outcomes to retrieval vs the answerer.
+
+    For every answerable question (non-empty ``ground_truth``) we join the QA
+    verdict with the retrieval row on ``(provider, query_id)``. A wrong answer
+    where the gold doc WAS retrieved (recall > 0) is an answerer failure
+    ("retrieved but unused"); a wrong answer where it was NOT retrieved is a
+    genuine retrieval miss. This separates "BM didn't find it" from "the fixed
+    answerer couldn't use what BM found" — the absolute QA number conflates the
+    two, and the answerer is held constant across providers.
+    """
+
+    provider: str
+    total_cases: int = 0
+    answerable: int = 0
+    unanswerable: int = 0  # empty ground_truth (abstention items) — no retrieval attribution
+    errored: int = 0  # QA-stage error (answerer/judge crashed)
+    unmatched: int = 0  # no retrieval row to join against
+    correct: int = 0
+    retrieved_but_unused: int = 0
+    truly_missed: int = 0
+    # Derived shares over answerable questions (0.0 when answerable == 0):
+    qa_accuracy: float = 0.0  # correct / answerable
+    retrieval_ceiling: float = 0.0  # (correct + retrieved_but_unused) / answerable — max QA if answerer were perfect
+    answerer_gap: float = 0.0  # retrieved_but_unused / answerable — headroom left on the table by the answerer
+    retrieval_gap: float = 0.0  # truly_missed / answerable — headroom that needs better retrieval
+    answerer_failure_share: float = 0.0  # retrieved_but_unused / (answerable failures) — of what we got wrong, how much was the answerer
+    recall_field: str = "recall_at_10"
+    by_category: dict[str, CategoryDiagnosis] = Field(default_factory=dict)
+
+
 class ProviderStatus(BaseModel):
     provider: str
     state: PROVIDER_STATE

--- a/src/basic_memory_benchmarks/runner.py
+++ b/src/basic_memory_benchmarks/runner.py
@@ -363,8 +363,18 @@ def run_review_stage(
     per-query-qa-rejudge.jsonl, 'auto' prefers the re-judged file when present.
     Writes review.html into the run dir and returns its path.
     """
-    from basic_memory_benchmarks.models import QACaseResult
     from basic_memory_benchmarks.scoring.review import build_review_html
+
+    cases, _chosen = _load_qa_cases(run_dir, source)
+
+    review_path = run_dir / "review.html"
+    review_path.write_text(build_review_html(cases, run_id=run_dir.name), encoding="utf-8")
+    return review_path
+
+
+def _load_qa_cases(run_dir: Path, source: str):
+    """Load QA cases, preferring the re-judged artifact under 'auto'."""
+    from basic_memory_benchmarks.models import QACaseResult
 
     rejudge_path = run_dir / "per-query-qa-rejudge.jsonl"
     qa_path = run_dir / "per-query-qa.jsonl"
@@ -373,7 +383,7 @@ def run_review_stage(
     else:
         chosen = qa_path
     if not chosen.exists():
-        raise FileNotFoundError(f"No QA artifact to review: {chosen}")
+        raise FileNotFoundError(f"No QA artifact to load: {chosen}")
 
     cases = []
     with chosen.open("r", encoding="utf-8") as file:
@@ -381,10 +391,42 @@ def run_review_stage(
             line = line.strip()
             if line:
                 cases.append(QACaseResult.model_validate(json.loads(line)))
+    return cases, chosen
 
-    review_path = run_dir / "review.html"
-    review_path.write_text(build_review_html(cases, run_id=run_dir.name), encoding="utf-8")
-    return review_path
+
+def run_diagnose_stage(
+    *,
+    run_dir: Path,
+    source: str = "auto",
+    recall_field: str = "recall_at_10",
+) -> Path:
+    """Attribute QA failures to retrieval vs the answerer for each provider.
+
+    Joins QA verdicts (per-query-qa[-rejudge].jsonl) with retrieval rows
+    (per-query-retrieval.jsonl) and writes qa-diagnosis.json, separating
+    "retrieved but unused" (answerer) failures from "truly missed" (retrieval)
+    failures. ``source``: 'qa' | 'rejudge' | 'auto' (prefers re-judged).
+    Returns the path to qa-diagnosis.json.
+    """
+    from basic_memory_benchmarks.scoring.diagnose import diagnose_run
+
+    qa_cases, chosen = _load_qa_cases(run_dir, source)
+    retrieval_rows = _load_retrieval_rows(run_dir)
+    diagnoses = diagnose_run(qa_cases, retrieval_rows, recall_field=recall_field)
+
+    out_path = run_dir / "qa-diagnosis.json"
+    out_path.write_text(
+        json.dumps(
+            {
+                "source": chosen.name,
+                "recall_field": recall_field,
+                "providers": [d.model_dump(mode="json") for d in diagnoses],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return out_path
 
 
 def run_rejudge_stage(

--- a/src/basic_memory_benchmarks/scoring/diagnose.py
+++ b/src/basic_memory_benchmarks/scoring/diagnose.py
@@ -1,0 +1,135 @@
+"""Answerer-vs-retrieval failure attribution.
+
+The QA pipeline is: provider retrieves → a FIXED answerer generates from the
+retrieved context → a FIXED judge grades vs gold. Because the answerer is held
+constant across providers, an absolute QA accuracy of, say, 0.75 conflates two
+very different things:
+
+  * retrieval found the gold evidence but the answerer didn't use it correctly
+    ("retrieved but unused" — an answerer failure, identical for every provider
+    given the same retrieved context), versus
+  * retrieval never surfaced the gold evidence ("truly missed" — a real
+    retrieval failure, the thing this project actually optimizes).
+
+This module joins the QA verdicts with the retrieval rows on
+``(provider, query_id)`` and splits each answerable failure into those two
+buckets. It turns "BM QA is 0.75" into "BM retrieval ceiling is 1.00; the 0.25
+gap is the answerer, not retrieval" — which is the honest, scrutiny-proof way to
+report what retrieval improvements can and cannot move.
+
+Unanswerable items (empty ``ground_truth`` — the abstention set) have no
+retrieval target, so they are counted separately and excluded from the
+attribution.
+"""
+
+from __future__ import annotations
+
+from basic_memory_benchmarks.models import (
+    CategoryDiagnosis,
+    PerQueryRetrievalResult,
+    ProviderDiagnosis,
+    QACaseResult,
+)
+
+
+def _recall_value(row: PerQueryRetrievalResult, recall_field: str) -> float:
+    return float(getattr(row, recall_field))
+
+
+def diagnose_provider(
+    qa_cases: list[QACaseResult],
+    retrieval_rows: list[PerQueryRetrievalResult],
+    *,
+    provider: str,
+    recall_field: str = "recall_at_10",
+) -> ProviderDiagnosis:
+    """Attribute one provider's QA outcomes to retrieval vs the answerer.
+
+    ``qa_cases`` and ``retrieval_rows`` may contain rows for other providers;
+    only those matching ``provider`` are considered. A question counts as
+    "retrieved" when its joined retrieval row has ``recall_field`` > 0.
+    """
+    recall_by_qid: dict[str, float] = {
+        row.query_id: _recall_value(row, recall_field)
+        for row in retrieval_rows
+        if row.provider == provider
+    }
+
+    diag = ProviderDiagnosis(provider=provider, recall_field=recall_field)
+    by_cat: dict[str, CategoryDiagnosis] = {}
+
+    for case in qa_cases:
+        if case.provider != provider:
+            continue
+        diag.total_cases += 1
+
+        if case.error:
+            diag.errored += 1
+            continue
+
+        # Unanswerable / abstention items carry no retrieval ground truth.
+        retrieval_row = next(
+            (r for r in retrieval_rows if r.provider == provider and r.query_id == case.query_id),
+            None,
+        )
+        if retrieval_row is not None and not retrieval_row.ground_truth:
+            diag.unanswerable += 1
+            continue
+        if retrieval_row is None and case.query_id not in recall_by_qid:
+            diag.unmatched += 1
+            continue
+
+        diag.answerable += 1
+        cat = by_cat.setdefault(case.category, CategoryDiagnosis())
+        cat.answerable += 1
+
+        if case.correct:
+            diag.correct += 1
+            cat.correct += 1
+            continue
+
+        # Wrong answer: attribute to retrieval (gold not found) or answerer.
+        retrieved = recall_by_qid.get(case.query_id, 0.0) > 0
+        if retrieved:
+            diag.retrieved_but_unused += 1
+            cat.retrieved_but_unused += 1
+        else:
+            diag.truly_missed += 1
+            cat.truly_missed += 1
+
+    _finalize(diag)
+    diag.by_category = dict(sorted(by_cat.items()))
+    return diag
+
+
+def _finalize(diag: ProviderDiagnosis) -> None:
+    answerable = diag.answerable
+    if answerable:
+        diag.qa_accuracy = diag.correct / answerable
+        diag.retrieval_ceiling = (diag.correct + diag.retrieved_but_unused) / answerable
+        diag.answerer_gap = diag.retrieved_but_unused / answerable
+        diag.retrieval_gap = diag.truly_missed / answerable
+    failures = diag.retrieved_but_unused + diag.truly_missed
+    if failures:
+        diag.answerer_failure_share = diag.retrieved_but_unused / failures
+
+
+def diagnose_run(
+    qa_cases: list[QACaseResult],
+    retrieval_rows: list[PerQueryRetrievalResult],
+    *,
+    recall_field: str = "recall_at_10",
+) -> list[ProviderDiagnosis]:
+    """Diagnose every provider present in ``qa_cases`` (stable provider order)."""
+    providers: list[str] = []
+    seen: set[str] = set()
+    for case in qa_cases:
+        if case.provider not in seen:
+            seen.add(case.provider)
+            providers.append(case.provider)
+    return [
+        diagnose_provider(
+            qa_cases, retrieval_rows, provider=provider, recall_field=recall_field
+        )
+        for provider in providers
+    ]

--- a/tests/test_diagnose.py
+++ b/tests/test_diagnose.py
@@ -1,0 +1,196 @@
+"""Tests for answerer-vs-retrieval failure attribution."""
+
+from __future__ import annotations
+
+import json
+
+from basic_memory_benchmarks.models import PerQueryRetrievalResult, QACaseResult
+from basic_memory_benchmarks.scoring.diagnose import diagnose_provider, diagnose_run
+
+
+def _qa(qid, correct, *, provider="bm-local", category="single_hop", abstained=False, error=None):
+    return QACaseResult(
+        provider=provider,
+        query_id=qid,
+        category=category,
+        question="q?",
+        expected_answer="gold",
+        generated_answer="ans",
+        abstained=abstained,
+        correct=correct,
+        judge_reason="reason",
+        answer_model="claude:haiku",
+        judge_model="claude:sonnet",
+        answer_latency_ms=1.0,
+        answer_input_tokens=1,
+        answer_output_tokens=1,
+        error=error,
+    )
+
+
+def _retr(qid, recall_at_10, *, provider="bm-local", ground_truth=("d1",)):
+    return PerQueryRetrievalResult(
+        provider=provider,
+        query_id=qid,
+        query_text="q?",
+        category="single_hop",
+        ground_truth=list(ground_truth),
+        hits=[],
+        recall_at_5=recall_at_10,
+        recall_at_10=recall_at_10,
+        precision_at_5=0.0,
+        mrr=0.0,
+        content_hit=False,
+        latency_ms=1.0,
+    )
+
+
+def test_attributes_failures_to_answerer_vs_retrieval():
+    qa = [
+        _qa("q1", True),  # correct
+        _qa("q2", False),  # wrong, gold retrieved -> answerer
+        _qa("q3", False),  # wrong, gold NOT retrieved -> retrieval
+    ]
+    retr = [_retr("q1", 1.0), _retr("q2", 1.0), _retr("q3", 0.0)]
+
+    d = diagnose_provider(qa, retr, provider="bm-local")
+
+    assert d.answerable == 3
+    assert d.correct == 1
+    assert d.retrieved_but_unused == 1
+    assert d.truly_missed == 1
+    assert d.qa_accuracy == 1 / 3
+    assert d.retrieval_ceiling == 2 / 3  # correct + retrieved-but-unused
+    assert d.answerer_gap == 1 / 3
+    assert d.retrieval_gap == 1 / 3
+    assert d.answerer_failure_share == 0.5  # 1 of 2 failures was the answerer
+
+
+def test_unanswerable_items_excluded_from_attribution():
+    qa = [_qa("q1", True), _qa("q2", False)]
+    retr = [_retr("q1", 1.0), _retr("q2", 0.0, ground_truth=())]  # q2 has no gold
+
+    d = diagnose_provider(qa, retr, provider="bm-local")
+
+    assert d.answerable == 1
+    assert d.unanswerable == 1
+    assert d.correct == 1
+    assert d.truly_missed == 0  # q2 not counted as a retrieval miss
+
+
+def test_errored_and_unmatched_are_bucketed_not_attributed():
+    qa = [
+        _qa("q1", False, error="llm died"),  # errored
+        _qa("q2", False),  # no retrieval row -> unmatched
+    ]
+    retr = [_retr("q1", 0.0)]
+
+    d = diagnose_provider(qa, retr, provider="bm-local")
+
+    assert d.total_cases == 2
+    assert d.errored == 1
+    assert d.unmatched == 1
+    assert d.answerable == 0
+    assert d.qa_accuracy == 0.0  # no division by zero
+
+
+def test_per_category_breakdown():
+    qa = [
+        _qa("q1", True, category="single_hop"),
+        _qa("q2", False, category="multi_hop"),  # retrieved
+        _qa("q3", False, category="multi_hop"),  # missed
+    ]
+    retr = [_retr("q1", 1.0), _retr("q2", 1.0), _retr("q3", 0.0)]
+
+    d = diagnose_provider(qa, retr, provider="bm-local")
+
+    assert d.by_category["single_hop"].correct == 1
+    assert d.by_category["multi_hop"].answerable == 2
+    assert d.by_category["multi_hop"].retrieved_but_unused == 1
+    assert d.by_category["multi_hop"].truly_missed == 1
+
+
+def test_recall_field_is_honored():
+    qa = [_qa("q1", False)]
+    # gold in top-10 but not top-5: answerer failure under r@10, retrieval miss under r@5
+    retr = [
+        PerQueryRetrievalResult(
+            provider="bm-local",
+            query_id="q1",
+            query_text="q?",
+            category="single_hop",
+            ground_truth=["d1"],
+            hits=[],
+            recall_at_5=0.0,
+            recall_at_10=1.0,
+            precision_at_5=0.0,
+            mrr=0.0,
+            content_hit=False,
+            latency_ms=1.0,
+        )
+    ]
+
+    assert diagnose_provider(qa, retr, provider="bm-local").truly_missed == 0
+    assert (
+        diagnose_provider(qa, retr, provider="bm-local", recall_field="recall_at_5").truly_missed
+        == 1
+    )
+
+
+def test_diagnose_run_covers_all_providers_in_stable_order():
+    qa = [_qa("q1", True, provider="bm-local"), _qa("q1", False, provider="mem0-local")]
+    retr = [_retr("q1", 1.0, provider="bm-local"), _retr("q1", 1.0, provider="mem0-local")]
+
+    diags = diagnose_run(qa, retr)
+
+    assert [d.provider for d in diags] == ["bm-local", "mem0-local"]
+    assert diags[0].correct == 1
+    assert diags[1].retrieved_but_unused == 1
+
+
+def test_diagnose_stage_writes_json(tmp_path):
+    from basic_memory_benchmarks import runner as runner_module
+
+    (tmp_path / "per-query-qa.jsonl").write_text(
+        "\n".join(
+            json.dumps(c.model_dump(mode="json"))
+            for c in [_qa("q1", True), _qa("q2", False), _qa("q3", False)]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "per-query-retrieval.jsonl").write_text(
+        "\n".join(
+            json.dumps(r.model_dump(mode="json"))
+            for r in [_retr("q1", 1.0), _retr("q2", 1.0), _retr("q3", 0.0)]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out = runner_module.run_diagnose_stage(run_dir=tmp_path, source="qa")
+    assert out.name == "qa-diagnosis.json"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    prov = payload["providers"][0]
+    assert prov["retrieved_but_unused"] == 1
+    assert prov["truly_missed"] == 1
+
+
+def test_diagnose_stage_prefers_rejudge_when_auto(tmp_path):
+    from basic_memory_benchmarks import runner as runner_module
+
+    (tmp_path / "per-query-retrieval.jsonl").write_text(
+        json.dumps(_retr("q1", 1.0).model_dump(mode="json")) + "\n", encoding="utf-8"
+    )
+    # Original judged it wrong; rejudge flips it to correct.
+    (tmp_path / "per-query-qa.jsonl").write_text(
+        json.dumps(_qa("q1", False).model_dump(mode="json")) + "\n", encoding="utf-8"
+    )
+    (tmp_path / "per-query-qa-rejudge.jsonl").write_text(
+        json.dumps(_qa("q1", True).model_dump(mode="json")) + "\n", encoding="utf-8"
+    )
+
+    out = runner_module.run_diagnose_stage(run_dir=tmp_path, source="auto")
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["source"] == "per-query-qa-rejudge.jsonl"
+    assert payload["providers"][0]["correct"] == 1


### PR DESCRIPTION
## What

Adds `bm-bench run diagnose`, which separates **retrieval failures** from **answerer failures** in the QA results.

The QA pipeline holds the answerer (`claude-haiku-4-5`) constant across all providers, so an absolute QA accuracy conflates two very different things:

- **retrieved but unused** — the gold evidence *was* retrieved, but the fixed answerer didn't use it correctly. This is an answerer failure, identical for every provider given the same retrieved context.
- **truly missed** — the gold evidence was never surfaced. This is a real retrieval failure — the only thing retrieval work can actually move.

`run diagnose` joins `per-query-qa[-rejudge].jsonl` with `per-query-retrieval.jsonl` on `(provider, query_id)` and splits each answerable failure into those buckets, writing `qa-diagnosis.json` and printing a per-provider table:

| field | meaning |
|---|---|
| `retrieval_ceiling` | max QA accuracy achievable if the answerer were perfect = (correct + retrieved-but-unused) / answerable |
| `answerer_gap` | headroom left on the table by the answerer |
| `retrieval_gap` | headroom that needs better retrieval |
| `answerer_failure_share` | of what we got wrong, how much was the answerer |

Unanswerable (empty `ground_truth`) and errored cases are bucketed separately and never attributed. Per-category breakdown included.

## Why it matters for credibility

Reading the three anchor runs (re-judged):

- **ConvoMem-cs10**: retrieval ceiling **1.000** for *every* provider — the haystack fits the top-10 window, so it is **not a retrieval test**. The BM > mem0 QA gap there is context presentation, not recall.
- **LongMemEval-60**: BM ceiling 0.983 (1 true miss) — 96% of BM failures are the answerer.
- **LoCoMo-q300**: BM ceiling **0.930**, 19% truly missed — the only anchor with real retrieval headroom.

This lets us make honest, scrutiny-proof claims about what retrieval improvements can and cannot change.

## Also

Refactors the QA-artifact loader (auto-prefers the re-judged file) into a shared `_load_qa_cases` helper now reused by both `review` and `diagnose`.

## Tests

9 new tests in `tests/test_diagnose.py` (attribution split, unanswerable/errored/unmatched bucketing, per-category, recall-field selection, multi-provider ordering, stage wiring, rejudge preference). Full suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)